### PR TITLE
feat(desktop): プロファイルごとに任意のカスタムアイコン（絵文字等）を設定できる機能を追加

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -99,7 +99,7 @@ fn main() -> anyhow::Result<()> {
                         sharing.desktop_worktrees = SharingMode::Share;
                     } // Else keep defaults (Isolate)
                     
-                    match manager.create_profile(&name, sharing) {
+                    match manager.create_profile(&name, sharing, None) {
                         Ok(_) => {
                             println!("{} Profile '{}' created successfully!", "✔".green(), name.cyan());
                             println!("  Desktop Data: {:?}", provider.app_data_dir().join("profiles").join(&name).join("desktop-data"));

--- a/crates/core/src/profile/mod.rs
+++ b/crates/core/src/profile/mod.rs
@@ -228,7 +228,7 @@ impl ProfileManager {
         config::load_profile(&profile_toml)
     }
 
-    pub fn create_profile(&self, name: &str, sharing: SharingConfig) -> Result<Profile> {
+    pub fn create_profile(&self, name: &str, sharing: SharingConfig, icon: Option<String>) -> Result<Profile> {
         if name == "default" {
             return Err(CswError::ProfileAlreadyExists("default".to_string()));
         }
@@ -244,7 +244,7 @@ impl ProfileManager {
         let profile = Profile {
             profile: ProfileMeta {
                 name: name.to_string(),
-                icon: "💼".to_string(),
+                icon: icon.unwrap_or_else(|| "".to_string()),
                 color: "#4A90D9".to_string(),
                 is_default: false,
             },

--- a/crates/core/src/profile/tests.rs
+++ b/crates/core/src/profile/tests.rs
@@ -39,7 +39,7 @@ fn test_default_profile() {
 fn test_create_profile() {
     let (_, manager, _tmp_dir) = setup_test_manager();
     
-    let profile = manager.create_profile("test_profile", SharingConfig::default())
+    let profile = manager.create_profile("test_profile", SharingConfig::default(), None)
         .expect("Failed to create profile");
         
     assert_eq!(profile.profile.name, "test_profile");
@@ -55,7 +55,7 @@ fn test_create_profile() {
 fn test_delete_profile() {
     let (_, manager, _tmp_dir) = setup_test_manager();
     
-    manager.create_profile("to_delete", SharingConfig::default())
+    manager.create_profile("to_delete", SharingConfig::default(), None)
         .expect("Failed to create profile");
         
     let list = manager.list_profiles().unwrap();
@@ -76,7 +76,7 @@ fn test_delete_default_or_active_fails() {
     assert!(res.is_err());
     
     // Deleting active fails
-    manager.create_profile("active_prof", SharingConfig::default()).unwrap();
+    manager.create_profile("active_prof", SharingConfig::default(), None).unwrap();
     manager.switch_to("active_prof").unwrap();
     
     let res2 = manager.delete_profile("active_prof");
@@ -88,7 +88,7 @@ fn test_clone_profile() {
     let (_, manager, _tmp_dir) = setup_test_manager();
     
     // Create an original profile to clone from
-    let original = manager.create_profile("original", SharingConfig::default())
+    let original = manager.create_profile("original", SharingConfig::default(), None)
         .expect("Failed to create original profile");
 
     // Clone it

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -92,7 +92,7 @@ fn test_full_profile_switch_workflow() {
 
     // Create a new profile
     let sharing_config = SharingConfig::default(); // default is Isolated
-    profile_manager.create_profile("Work", sharing_config).unwrap();
+    profile_manager.create_profile("Work", sharing_config, None).unwrap();
 
     // Switch to the new profile
     switcher.switch_to("Work").unwrap();
@@ -151,7 +151,7 @@ fn test_profile_sharing_and_isolation_matrix() {
         source: SharingSource::default(),
     };
 
-    let profile = profile_manager.create_profile("CustomMatrix", matrix_sharing).unwrap();
+    let profile = profile_manager.create_profile("CustomMatrix", matrix_sharing, None).unwrap();
     let target_desktop = &profile.isolation.desktop_user_data_dir;
     let target_cli = &profile.isolation.cli_config_dir;
 
@@ -225,7 +225,7 @@ fn test_profile_cloning_with_data() {
     let mut sharing = SharingConfig::default();
     sharing.cli_skills = SharingMode::Copy;
     sharing.cli_sessions = SharingMode::Isolate;
-    let _original_profile = profile_manager.create_profile("OriginalWork", sharing).unwrap();
+    let _original_profile = profile_manager.create_profile("OriginalWork", sharing, None).unwrap();
 
     // Switch to generate credential backup inside OriginalWork
     switcher.switch_to("OriginalWork").unwrap();

--- a/crates/desktop/src/main.rs
+++ b/crates/desktop/src/main.rs
@@ -25,8 +25,19 @@ async fn get_active_profile(state: State<'_, AppState>) -> Result<String, String
 }
 
 #[tauri::command]
-async fn list_profiles(state: State<'_, AppState>) -> Result<Vec<String>, String> {
-    state.profile_manager.list_profiles().map_err(|e| e.to_string())
+async fn list_profiles(state: State<'_, AppState>) -> Result<Vec<serde_json::Value>, String> {
+    let names = state.profile_manager.list_profiles().map_err(|e| e.to_string())?;
+    let mut list = Vec::new();
+    for name in names {
+        if let Ok(p) = state.profile_manager.get_profile(&name) {
+            list.push(serde_json::json!({
+                "name": p.profile.name,
+                "icon": p.profile.icon,
+                "is_default": p.profile.is_default,
+            }));
+        }
+    }
+    Ok(list)
 }
 
 #[tauri::command]
@@ -59,6 +70,7 @@ async fn get_profile_details(name: String, state: State<'_, AppState>) -> Result
 async fn create_profile(
     name: String,
     mode: String,
+    icon: Option<String>,
     state: State<'_, AppState>,
     app: AppHandle,
 ) -> Result<(), String> {
@@ -71,7 +83,7 @@ async fn create_profile(
         sharing.desktop_worktrees = SharingMode::Share;
     }
 
-    state.profile_manager.create_profile(&name, sharing).map_err(|e| e.to_string())?;
+    state.profile_manager.create_profile(&name, sharing, icon).map_err(|e| e.to_string())?;
     
     // Update system tray menu after change
     update_tray_menu(&app)?;

--- a/crates/desktop/ui/index.html
+++ b/crates/desktop/ui/index.html
@@ -133,6 +133,10 @@
             <input type="text" id="input-name" placeholder="例: Work, Personal, Research">
           </div>
           <div class="form-group">
+            <label for="input-icon">アイコン (絵文字等 - 任意)</label>
+            <input type="text" id="input-icon" placeholder="例: 💼, 🏠, 🧪 (空欄なら頭文字)" maxlength="2">
+          </div>
+          <div class="form-group">
             <label for="select-preset">設定プリセット</label>
             <select id="select-preset">
               <option value="isolate">分離 (独立した設定・メモリ・データ)</option>

--- a/crates/desktop/ui/main.js
+++ b/crates/desktop/ui/main.js
@@ -6,12 +6,16 @@
 const invoke = window.__TAURI__ ? window.__TAURI__.core.invoke : async (cmd, args) => {
   console.log(`Mock calling command "${cmd}" with args:`, args);
   // Mock implementations for design testing
-  if (cmd === 'list_profiles') return ['default', 'Work', 'Personal'];
+  if (cmd === 'list_profiles') return [
+    { name: 'default', icon: '', is_default: true },
+    { name: 'Work', icon: '💼', is_default: false },
+    { name: 'Personal', icon: '🏠', is_default: false }
+  ];
   if (cmd === 'get_active_profile') return 'default';
   if (cmd === 'get_profile_details') {
     return {
       name: args.name,
-      icon: args.name.charAt(0).toUpperCase(),
+      icon: args.name === 'default' ? '' : (args.name === 'Work' ? '💼' : '🏠'),
       color: '#4A90D9',
       is_default: args.name === 'default',
       desktop_path: `~/.claude-desktop-switcher/profiles/${args.name.toLowerCase()}/desktop-data`,
@@ -69,6 +73,7 @@ const elBtnAddProfile = document.getElementById('btn-add-profile');
 // Modal Elements
 const elModalCreate = document.getElementById('modal-create');
 const elInputName = document.getElementById('input-name');
+const elInputIcon = document.getElementById('input-icon');
 const elSelectPreset = document.getElementById('select-preset');
 const elBtnModalCancel = document.getElementById('btn-modal-cancel');
 const elBtnModalSubmit = document.getElementById('btn-modal-submit');
@@ -107,7 +112,7 @@ async function refreshProfiles() {
     renderProfileList();
     
     // Auto-select active profile detail if none is selected
-    if (selectedProfileName && profilesList.includes(selectedProfileName)) {
+    if (selectedProfileName && profilesList.some(p => p.name === selectedProfileName)) {
       await showProfileDetails(selectedProfileName);
     } else {
       elDetailsPanel.classList.add('hidden');
@@ -123,15 +128,15 @@ async function refreshProfiles() {
 function renderProfileList() {
   elProfileList.innerHTML = '';
   
-  profilesList.forEach(name => {
-    const isActive = name === activeProfileName;
-    const initial = name.charAt(0).toUpperCase();
+  profilesList.forEach(p => {
+    const isActive = p.name === activeProfileName;
+    const iconContent = p.icon ? p.icon : p.name.charAt(0).toUpperCase();
     
     const li = document.createElement('li');
-    li.className = `profile-item ${name === selectedProfileName ? 'active' : ''}`;
+    li.className = `profile-item ${p.name === selectedProfileName ? 'active' : ''}`;
     li.innerHTML = `
-      <span class="profile-avatar">${initial}</span>
-      <span class="profile-name">${name}</span>
+      <span class="profile-avatar">${iconContent}</span>
+      <span class="profile-name">${p.name}</span>
       ${isActive ? '<span class="active-dot"></span>' : ''}
     `;
     
@@ -139,7 +144,7 @@ function renderProfileList() {
       // Remove active class from previous
       document.querySelectorAll('.profile-item').forEach(el => el.classList.remove('active'));
       li.classList.add('active');
-      showProfileDetails(name);
+      showProfileDetails(p.name);
     });
     
     elProfileList.appendChild(li);
@@ -161,7 +166,7 @@ async function showProfileDetails(name) {
     elDetailsPanel.classList.remove('hidden');
     
     // Meta info
-    elDetailIcon.textContent = p.name.charAt(0).toUpperCase();
+    elDetailIcon.textContent = p.icon ? p.icon : p.name.charAt(0).toUpperCase();
     elDetailName.textContent = p.name;
     
     // Status Tag
@@ -221,6 +226,7 @@ function setupEventListeners() {
   // Create Profile Modal
   elBtnAddProfile.addEventListener('click', () => {
     elInputName.value = '';
+    elInputIcon.value = '';
     elModalCreate.classList.remove('hidden');
     elInputName.focus();
   });
@@ -231,6 +237,7 @@ function setupEventListeners() {
   
   elBtnModalSubmit.addEventListener('click', async () => {
     const name = elInputName.value.trim();
+    const icon = elInputIcon.value.trim();
     const mode = elSelectPreset.value;
     
     if (!name) {
@@ -250,7 +257,7 @@ function setupEventListeners() {
     }
     
     try {
-      await invoke('create_profile', { name, mode });
+      await invoke('create_profile', { name, mode, icon: icon || null });
       elModalCreate.classList.add('hidden');
       selectedProfileName = name;
       await refreshProfiles();


### PR DESCRIPTION
ユーザー自身がプロファイル一覧で好みの絵文字アイコン（例: 💼, 🏠 等）を任意に選択・設定できるカスタマイズ機能を追加しました。アイコン未指定の場合は、従来通りプロファイル名の頭文字が大文字のアバターとして美しく描画され、高品位なUIデザインと実用的な個別視認性を両立させています。