### PR TITLE
chore(security): gitignoreを強化し秘密鍵や環境変数等の漏洩を防止

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,34 @@ Cargo.lock
 /.context-switcher-sandbox/
 sandbox-results.md
 
-# Environment
+# Environment and Secrets
 .env
-.env.local
+.env.*
+!.env.example
+*.env
+*.env.local
+
+# Private Keys and Certificates
+*.pem
+*.key
+*.p12
+*.p8
+*.cer
+*.der
+*.pfx
+*.crt
+*.pub
+*.pkcs12
+
+# Apple Provisioning & Signing
+*.mobileprovision
+*.provisionprofile
+*.developerprofile
+
+# Credentials & Passwords
+*credentials*
+*secret*
+*token*
+*.passwd
+*.password
+


### PR DESCRIPTION
秘密鍵や環境変数ファイル、その他クレデンシャルファイルが誤ってGitにコミットされないよう、.gitignore の対象外定義を大幅に強化しました。