### PR TITLE
docs(agents): worktree隔離・多エージェント安全開発のスキル群を移植

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -3,6 +3,23 @@
 ## Persona & Core Directives
 You are a Senior Agentic Engineer operating in 2026. You strictly follow structural separation of concerns, meaning you never confuse public web assets (LP) with internal documentation or agent files.
 
+## Skill トリガーテーブル
+以下の条件に合致したら、該当する `.agents/skills/<name>/SKILL.md` を `Read` で読み、その手順に従う。`/bugfix` `/spec-first` はスラッシュコマンドからも起動できる。
+
+| 発動条件 | スキル |
+|---|---|
+| 派生サブタスク (spawn_task / Agent 委譲 / 別 PR 化 / CI 待ち中の並行作業 / 割り込み) を始めるとき | `core_worktree_for_derived_tasks` |
+| 新規実装・大幅修正の着手前、セッション開始/終了時 (Plan を `docs/proposals/` でバトンパス) | `core_session_handoff` |
+| 「完了/PASS」と報告する前・PR 提出前・リファクタ/名称変更後 (検証順序とエビデンス強制) | `core_qa_process` |
+| PR をマージする / マージ可否を判断するとき | `core_pr_merge_checklist` |
+| CI (GitHub Actions) が 10 分以上ハングしている疑いのとき | `core_ci_hang_recovery` |
+| 複数 crate / 複数ファイルにまたがる作業を役割分担で進めるとき | `core_agent_roles` |
+| 多段の調査・実装・検証を並列化したいとき (Workflow / サブエージェント) | `core_ai_workflow` |
+| バグ修正に着手するとき (RED テストファースト) | `core_bug_fix_protocol` (`/bugfix`) |
+| 新機能・仕様変更に着手するとき (仕様合意→RED→GREEN) | `core_spec_first_development` (`/spec-first`) |
+| git commit する直前 | `core_commit_standard` |
+| PR 完成時のレビューサイクル | `core_pr_review_cycle` |
+
 ## Coding Standards & Constraints
 1. **Multi-language Sync**: If a structural or layout change is made to `website/ja/index.html`, you MUST simultaneously apply the same change to `website/index.html` (and vice versa). Never let localized versions diverge structurally.
 2. **Repository Architecture**:

--- a/.agents/skills/core_agent_roles/SKILL.md
+++ b/.agents/skills/core_agent_roles/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: core_agent_roles
+description: CSW (Rust + Tauri v2) のマルチエージェント・ロール定義。Architect / Core Engineer / Desktop・UI / Documenter / QA の責務と行動指針を規定し、Task(Agent) サブエージェントや Workflow ステージで実体化する。複数ファイル・複数 crate にまたがる作業をチーム分業で進めるとき、役割分担や責務境界を確認したいときに参照する。
+---
+
+# マルチエージェント・ロール定義 (CSW)
+
+Claude Desktop Switcher (CSW) は Rust + Tauri v2 の macOS アプリ。実質的な作業はこのスキルが定義する 5 つのロールに分業し、各ロールを **Task(Agent) サブエージェント** または **Workflow のステージ** として実体化する。1 セッション内で 1 人が複数ロールを順番に被ってもよいが、責務の境界 (特にセキュリティと検証) は被っても緩めない。
+
+> [!CAUTION]
+> **どのロールも「できた」と報告する前に、自分でエビデンスを確認する義務がある。**
+> このリポジトリでは `cargo` がローカルで使えない環境があるため、**検証の正典は CI** (test.yml / build.yml)。GUI 変更は `cargo tauri dev` のスクリーンショット、core/CLI 変更は CI のテスト/ビルド結果を一次情報として確認する。サブエージェントの「PASS」報告を鵜呑みにしない (`core_spec_first_development` 参照)。
+
+---
+
+## ロール早見表
+
+| ロール | 担当 crate / 領域 | 主責務 |
+|---|---|---|
+| **Architect** (統括) | workspace 全体 | タスク分割・統合、crate 境界と整合性の維持、仕様未定義領域の合意取り |
+| **Core Engineer** | `crates/core` (csv-core) | ロジック+データ、回帰テスト、**セキュリティファースト** |
+| **Desktop / UI** | `crates/desktop` (csw-desktop, Tauri v2) | WebView を dumb terminal に保ち、ロジックは Rust 側に置く |
+| **Documenter** | `docs/SPECIFICATION.md` ほか | 仕様の正典化と即時最新化、テスト条件の先行言語化 |
+| **QA** | workspace 全体 + GUI | build / launch / test の検証、エビデンス確認 |
+
+CLI (`crates/cli`, csw-cli) はロジックを `crates/core` に委譲する薄い殻として扱い、Core Engineer が core と一体で面倒を見る。
+
+---
+
+## 1. The Architect (統括)
+
+- タスクを上記ロールへ分割・委譲し、最後に統合して整合性を取る。Workflow の DAG 設計やサブエージェントへの指示作成はここが担う
+- **crate 境界を守る**: ロジックとデータは `crates/core`、UI/IPC 配線は `crates/desktop`、コマンドライン I/O は `crates/cli`。ロジックが desktop/cli に漏れていたら core へ引き戻す設計判断をする
+- 仕様が未定義の領域を発見したら **AI の裁量で勝手に埋めず**、`docs/SPECIFICATION.md` に明文化してユーザーと合意を取る (方針が割れる不可逆な分岐のみ `AskUserQuestion`、それ以外は推奨を添えて自走)
+- `.agents/skills/` の継続的改善 (知識の代謝) もこのロールの責務
+
+## 2. The Core Engineer (ロジック・データ / `crates/core`)
+
+- `crates/core` のドメインロジックとデータ構造を実装。CLI/Desktop から呼ばれる API はここに集約する
+- **ロジック変更時は回帰テストを必ず追加** (`#[cfg(test)]` / integration test)。CI の test job (`cargo test --workspace --exclude csw-desktop`) が core+cli を回すので、ここが緑になることを確認する
+- **セキュリティファースト (最重要・妥協禁止)**:
+  - **IPC 入力は信頼しない**。Tauri command の引数 (WebView 由来) はすべて untrusted。パス・識別子・数値は受け取った直後に検証/正規化し、`crates/core` 側で境界チェックする。`unwrap`/`expect` でユーザ入力起因の panic を作らない
+  - **Tauri capability は wildcard 禁止**。`crates/desktop` の capabilities/permissions は使う command だけを最小許可で列挙する。`"*"` や過剰スコープを足さない
+  - エッジケース (空入力・不正パス・存在しない対象・権限不足) を網羅し、エラーは `Result` で返す
+- 利便性のためにセキュリティ/プライバシー/倫理を犠牲にしない。トレードオフが必要に見えたら設計を見直すか Architect に差し戻す
+
+## 3. The Desktop / UI (`crates/desktop`, Tauri v2)
+
+- **WebView は dumb terminal として扱う**: 表示と入力受付に徹し、判断ロジック・状態遷移・データ整形は Rust (core / desktop の Rust 側) に置く。フロントに業務ロジックを溜めない
+- Tauri command の追加時は (a) core のロジックを呼ぶ薄いラッパにする、(b) 入力検証を core 側に通す、(c) capability を最小許可で追加する、の 3 点を Core Engineer の規律に従って満たす
+- 新規 UI 文言は日本語で直書きしてよい (ユーザ向け文言の正典は `docs/USER_GUIDE.md` / 英語は `docs/USER_GUIDE_EN.md`)
+- 変更後は `cargo tauri dev` で起動して目視確認。**定性的な UX 評価は人間に委ねる**
+- このリポには npm / Next.js / Supabase / Expo は無い。Web フレームワーク前提の手順を持ち込まない
+
+## 4. The Documenter (仕様・記録 / `docs/`)
+
+- **仕様の正典は `docs/SPECIFICATION.md`** (blueprint.md ではない)。挙動を変えたら即時に追記/更新する
+- 実装前に、テストのアサーション条件 (期待する入出力・エラー) を `docs/SPECIFICATION.md` に **先行言語化** する。テストの期待値は仕様書から導出し、コードの現挙動を正解にしない
+- セッション計画・設計提案は `docs/proposals/` に置く (無ければ作成)。ユーザ向け手順は `docs/USER_GUIDE.md` を同期する
+
+## 5. The QA Agent (検証)
+
+- **検証の正典は CI**: PR を出したら test.yml (core+cli の `cargo test`) と build.yml (desktop 含む workspace の `cargo build`)、security.yml の結果を確認する。ローカルで `cargo` が動く環境なら下記をローカルでも回す
+  - `cargo fmt --check`
+  - `cargo clippy --workspace --all-targets -- -D warnings`
+  - `cargo build --workspace`
+  - `cargo test --workspace`
+  - GUI: `cargo tauri dev` で起動して目視
+- テスト基準は **仕様 (`docs/SPECIFICATION.md`) に向ける**。コードの現挙動を正解として固定しない
+- **エビデンスなき PASS は虚偽報告と同等**。スクリーンショット/CI ログ/コマンド出力を自分で開いて確認してから「PASS」と言う
+- 人間の承認ゲート: 仕様確定時、`main` へのマージ判断 (CI 緑が前提)、`clippy`/`rustfmt` の意図的 allow 追加時
+
+---
+
+## 実行と統合 (Workflow / Task)
+
+- **大きな作業は静的な手順ではなく Workflow の動的フィードバックループで回す**: 実装 → CI で `cargo build`/`test`/`clippy` → 失敗を解析 → 修正 → 収束、を繰り返す。確認で止めず推奨処理で自走する
+- ロールはサブエージェント (Task/Agent) に割り当ててよい。Architect が指示を書き、Core/Desktop/Documenter/QA を並列または順次に走らせ、結果を Architect が統合する
+- **すべての作業は repo 内 `.claude/worktrees/<name>` の worktree で行う** (`/tmp` 不可)。参照前に `git fetch origin main`、main へ直接 push しない
+- PR レビューは `/code-review`。CI が緑になったら `gh pr merge --squash` で自律マージする (`--admin` / `--no-verify` は使わない、CI を待つ)
+- 使うツールは Claude Code の Read / Grep / Glob / Edit / Bash / Task(Agent) / Workflow / Skill

--- a/.agents/skills/core_ci_hang_recovery/SKILL.md
+++ b/.agents/skills/core_ci_hang_recovery/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: core_ci_hang_recovery
+description: CI (GitHub Actions の Test / Build / Security job) が想定時間を大幅に超過した場合のハング検出と cancel / rerun フロー。macos-latest runner の混雑や cargo の依存取得・コンパイル stall 等、transient な GHA 側障害の典型対処。CI が想定より長く `in_progress` のまま動かない時に発動。
+---
+
+# CI ハング検出と recovery
+
+## 1. 背景
+
+CSW の CI は GitHub Actions 上で動く Rust ワークフロー群:
+
+| Workflow | runner | 内容 | 通常の目安 |
+|---|---|---|---|
+| **Test** | macos-latest | `cargo test --workspace --exclude csw-desktop` (core + cli) | 数分〜十数分 (依存コンパイル含む) |
+| **Build** | macos-latest | `cargo build --workspace` (desktop 含む全 crate) | 数分〜十数分 |
+| **Security** | ubuntu-latest | gitleaks secret scan | 1〜2 分 |
+
+これらを大幅に超えて `in_progress` のまま動かない場合、特定 step (toolchain setup / 依存 crate の取得・コンパイル / runner 起動待ち) でハングしている可能性が高い。
+
+CSW で疑うべき transient 障害の典型:
+
+- **macos-latest runner の混雑**: macOS runner はキューが詰まりやすく、起動・割当待ちで `queued` / `in_progress` が長引くことがある。
+- **cargo の依存取得 stall**: crates.io / registry への network が一時的に詰まり `Updating crates.io index` や `Downloading` で固まる。
+- **コンパイル中のメモリ/IO 枯渇**: 大きい依存ツリーで runner リソースが逼迫し step が進まなくなる。
+
+> いずれも **PR のコード側ではなく GHA runner 側の transient な問題**。force push やブランチ切り直しでは直らない。cancel + rerun が正解 (§5 アンチパターン参照)。
+
+放置すると:
+- マージできず止まり、ユーザー体験が悪化する
+- バックグラウンド polling が無限ループする
+- 後続 PR の rebase / branch update も詰まる
+
+## 2. いつ実行するか
+
+以下のいずれかに該当する時:
+
+- CI 状態が **10 分以上 `in_progress`** のまま step が進まない
+- バックグラウンド poll タスクが想定の倍の時間を超えても完了しない
+- ユーザーから「CI 固まってない?」と指摘された時
+
+> 注意: CSW の Test / Build は依存コンパイルで通常でも数分〜十数分かかる。**「遅い」だけで即 cancel しない**。step が `in_progress` のまま進捗が止まっているか (§3.1 で step 名を確認) を見て判断する。
+
+## 3. 手順
+
+`<owner>/<repo>` は `matsumotory/claude-desktop-switcher`。`<branch>` は作業ブランチ。
+
+### 3.1 ハングしている step を特定
+
+```bash
+RUN_ID=$(gh run list --repo <owner>/<repo> --branch <branch> --limit 1 --json databaseId --jq '.[0].databaseId')
+
+# job ごとに in_progress な step 名を出す (Test / Build を見分ける)
+gh run view "$RUN_ID" --repo <owner>/<repo> --json jobs \
+  --jq '.jobs[] | {job: .name, step: (.steps[] | select(.status=="in_progress") | .name)}'
+```
+
+例: `Setup Rust` / `Build all crates` / `Run unit and integration tests` が長時間 `in_progress` のまま、かつ進捗ログが止まっていればハングと判断する。`gh run view "$RUN_ID" --repo <owner>/<repo> --log | tail -50` でログ末尾も確認するとよい (`Downloading` / `Updating crates.io index` で固まっていれば network stall)。
+
+### 3.2 Cancel + Rerun
+
+```bash
+gh run cancel "$RUN_ID" --repo <owner>/<repo>
+
+# cancel は async — completed を待ってから rerun
+until [[ "$(gh run view "$RUN_ID" --repo <owner>/<repo> --json status --jq '.status')" == "completed" ]]; do
+  sleep 5
+done
+
+gh run rerun "$RUN_ID" --repo <owner>/<repo>
+```
+
+> `gh run rerun` は cancel 中 / in_progress 中は実行できない (`cannot be rerun; This workflow is already running`)。必ず `completed` を待つ。
+
+failed した job だけ再実行したい場合は `gh run rerun "$RUN_ID" --repo <owner>/<repo> --failed`。runner 混雑が原因の rerun はそのまま全 job で問題ない。
+
+### 3.3 Re-run 完了をハング検出付きで待つ
+
+CSW の Test / Build はコンパイル時間が長いので、houlens よりタイムアウトを長めに取る。**最大 20 分タイムアウト + step 詳細出力**で polling する:
+
+```bash
+START=$(date +%s)
+until [[ "$(gh pr view <PR> --repo <owner>/<repo> --json statusCheckRollup --jq '[.statusCheckRollup[].status] | all(. == "COMPLETED")')" == "true" ]]; do
+  NOW=$(date +%s)
+  if (( NOW - START > 1200 )); then
+    echo "[WARN] CI > 20min, check for hang"
+    RUN_ID=$(gh run list --repo <owner>/<repo> --branch <branch> --limit 1 --json databaseId --jq '.[0].databaseId')
+    gh run view "$RUN_ID" --repo <owner>/<repo> --json jobs \
+      --jq '.jobs[] | {job: .name, step: (.steps[] | select(.status=="in_progress") | .name)}'
+    break
+  fi
+  sleep 30
+done
+```
+
+これで 20 分以上ハングしたら自動検知 → ユーザーに報告できる。
+
+## 4. バックグラウンド polling の作法
+
+長時間 (>5 分) 待つ CI 監視は `Bash` の `run_in_background: true` でバックグラウンド化する。ただし:
+
+- **必ず最大タイムアウトを設ける** (無限ループ禁止)
+- **ハング検出条件** (step 単位の進捗チェック) を組み込む
+- 完了通知が来たら出力を確認してから次の判断に進む
+- CSW は Test / Build / Security の複数 workflow が走るので、`statusCheckRollup` を **全 check 集約** (上記 `all(. == "COMPLETED")`) で判定する。1 件だけ見て早合点しない
+
+## 5. アンチパターン
+
+- ❌ **「遅い」だけで即 cancel する**: CSW の Test / Build は依存コンパイルで通常でも数分〜十数分かかる。step が実際に止まっているか確認してから cancel する
+- ❌ **ハングしているのに force push / branch 切り直しで「直そうとする」**: 原因は GHA runner 側 (macos-latest 混雑 / network stall) で PR コード側ではない。cancel + rerun が正解
+- ❌ **ユーザーに知らせず無限に待つ**: 20 分超えたら自分から「CI が想定より長い、ハングの可能性」と報告する
+- ❌ **`gh run rerun` を cancel 完了前に呼ぶ**: エラーになる。`completed` を待つ
+- ❌ **`--admin` / `--no-verify` でゲートを飛ばしてマージ回避する**: ハング回避を口実に検証を飛ばさない。CI green を待ってから `gh pr merge --squash` (上位ルール参照)
+
+## 6. 切り分けの目安
+
+| 症状 | 疑い | 対処 |
+|---|---|---|
+| `queued` のまま長い | macos-latest runner キュー混雑 | 数分待つ。10 分超なら cancel + rerun |
+| `Setup Rust` で止まる | toolchain 取得 stall | cancel + rerun |
+| `Updating crates.io index` / `Downloading` で止まる | registry network stall | cancel + rerun |
+| コンパイル途中で長時間無進捗 | runner リソース逼迫 | cancel + rerun |
+| 特定 test が毎回同じ所で落ちる/固まる | **コード側の問題 (transient ではない)** | rerun せず実装を疑う (`bugfix` skill へ) |
+
+最後の行が重要: **rerun して同じ step で再現するならコード側の問題**。transient かどうかは「1 回 rerun して直るか」で切り分ける。2 回同じ所でハング/失敗したら GHA 側ではなく実装・依存定義を疑い、cargo (CI 上) で再現させて直す。
+
+## 7. 関連
+
+- 関連スキル: `core_pr_review_cycle` (PR フロー / マージ判定), `modern-rust-workflow` (cargo 検証コマンド全般), `core_bug_fix_protocol` (rerun でも直らない = コード側のとき)
+- 上位ルール: CI green を待ってから `gh pr merge --squash`、`--admin` / `--no-verify` は使わない。`main` への直接 push 禁止、作業は `.claude/worktrees/<name>` で隔離

--- a/.agents/skills/core_pr_merge_checklist/SKILL.md
+++ b/.agents/skills/core_pr_merge_checklist/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: core_pr_merge_checklist
+description: PR をマージする際のレビュー・マージ実行チェックリスト (Rust + Tauri v2 / CSW)。スコープ外変更・安全装置の格下げ・テスト負債・高リスクインフラファイル改変を検出し、CI green を確認したうえで自律的に squash merge する手順を定義する。
+---
+
+# PR マージチェックリスト
+
+PR (自分・他エージェント・共同作業者が作成したもの) をマージ可否判断し、実際にマージするまでのプロトコル。CSW は Rust + Tauri v2 macOS アプリ。verification の一次経路は CI (cargo がローカルに無い env がある)。
+
+## 発動条件
+
+- PR をマージしようとするとき / マージ可否を判断するとき。
+- レビュー (`/code-review`) が一巡し、指摘対応が済んだ後の最終ゲートとして。
+
+## 0. マージ前の前提 (常に)
+
+- worktree (`.claude/worktrees/<name>`) で作業する。primary checkout は読まない・触らない。
+- 参照前に必ず `cd <repo> && git fetch origin main`。ローカル checkout は信用しない。
+- `main` に直接 push しない。マージは PR 経由 (`gh pr merge`) のみ。
+
+## 1. スコープの厳密確認
+
+PR の全 diff がタイトル・説明の目的と一致しているか確認する。
+
+> [!CAUTION]
+> **スコープ外の変更は最大のリスク**。「ついで修正」で無関係なインフラ設定が混入する事故は実際に起きる。diff を端から端まで読む。
+
+- [ ] 全 diff が PR タイトル・説明の目的と合致しているか
+- [ ] 無関係な「ついで修正」が混入していないか (リファクタ・依存追加・設定変更)
+- [ ] **想定外の大量削除がないか** (関数・テスト・ガードのまとめ消し)
+- [ ] 高リスクインフラファイルの変更に特に注意 (下記)
+
+### 高リスクインフラファイル (CSW)
+
+これらが diff に含まれたら、変更理由が PR の目的と直結しているか必ず精査する:
+
+- `crates/desktop/tauri.conf.json` — CSP / 権限 / バンドル / 署名設定
+- `crates/desktop/capabilities/*` — Tauri v2 capability (コマンド許可範囲)
+- ルート・各 crate の `Cargo.toml` — 依存追加 / feature / edition (2024)
+- `.github/workflows/release.yml`・署名 / entitlement / notarization 関連
+- `.github/workflows/{test,build,security}.yml` — CI 定義そのもの
+
+## 2. 安全装置の緩和検出 (Rust 視点)
+
+既存の防御ロジック・エラーハンドリングが弱められていないか確認する。以下は **格下げの臭い**:
+
+- [ ] `Result` / `Option` → `unwrap_or_default()` でエラーを握り潰していないか
+- [ ] `.expect()` / 明示的なエラー伝播 → silent return (`return Ok(())` / 早期 return) への置換
+- [ ] `#[allow(...)]` を足して clippy / コンパイラ warning を黙らせていないか (追加時はユーザー承認必須)
+- [ ] CSP / capability の wildcard 化 (`"*"`, 過剰な scope, `dangerous*` の追加)
+- [ ] 入力バリデーション・権限ガード・パス検証の削除や緩和
+- [ ] `unsafe` ブロックの新規追加 (正当性が説明されているか)
+
+> [!CAUTION]
+> セキュリティ / プライバシー / 倫理を「楽だから」で交換しない。安全装置の緩和が見つかったら、利便性を理由にした緩和は却下する。
+
+## 3. テストの健全性
+
+テスト負債を増やす変更を防止する。
+
+> [!IMPORTANT]
+> **安直なテスト無効化は禁止**。テストを落とす / 飛ばすなら代替カバレッジの作成が必須。
+
+- [ ] `#[ignore]` が追加されていないか
+- [ ] `#[cfg(not(test))]` や条件付きコンパイルでテスト経路を握り潰していないか
+- [ ] テストの削除は、同等以上の代替カバレッジがある場合のみ許容
+- [ ] アサーションの弱体化 (`assert_eq!` → 緩い条件 / コメントアウト) がないか
+- [ ] ロジックは `crates/core` (csw-core) にテストが付いているか
+
+## 4. CI 状態の確認
+
+CSW の CI ジョブ構成を踏まえて判定する:
+
+- **Test** (`test.yml`): `cargo test --workspace --exclude csw-desktop` (= core + cli)
+- **Build** (`build.yml`): `cargo build --workspace` (desktop 含む全 crate)
+- **Security** (`security.yml`): gitleaks による secret scan
+
+チェック:
+
+- [ ] 上記 CI ジョブが全て green か (`gh pr checks <num>` で確認)
+- [ ] 失敗が main 既存の問題か、この PR 起因かを区別する
+- [ ] **PR 起因の失敗があるまま絶対にマージしない**
+- [ ] secret scan (gitleaks) の指摘は最優先で対処
+
+> [!NOTE]
+> CI test は desktop を除外、build は desktop を含む。desktop (Tauri) 側のコンパイルエラーは Test を素通りし Build で初めて落ちる。Tauri 関連の変更があるときは Build の結果を必ず確認する。
+
+## 5. ローカル / pre-push 品質ゲート
+
+CI に clippy / fmt ジョブは無い。これらは push 前のローカル検証で担保する (cargo が無い env では CI build/test 通過 + diff レビューで代替):
+
+- [ ] `cargo fmt --check` — フォーマット差分なし
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — warning ゼロ
+- [ ] `cargo build --workspace` / `cargo test --workspace` — 通過
+- [ ] GUI 挙動に関わる変更は `cargo tauri dev` で実機確認 (可能なら)
+
+## 6. レビュー指摘の反映
+
+- [ ] `/code-review` のインライン指摘を確認し、妥当な指摘は反映する
+- [ ] 言語ルール違反 (コメント / doc の言語統一) の指摘は必ず対応する
+- [ ] spec に影響する変更は `docs/SPECIFICATION.md` (canon) と整合しているか
+- [ ] セッション計画は `docs/proposals/` と矛盾していないか
+
+## マージ判定フロー
+
+```
+PR の diff を端から端まで確認
+  ├─ スコープ外の変更あり        → ❌ 修正要求 or 部分取り込み
+  ├─ 安全装置の格下げあり        → ❌ 却下 (セキュリティ/プライバシー)
+  ├─ 高リスクインフラ改変が無根拠 → ❌ 説明を求める / 却下
+  ├─ #[ignore] 等のテスト無効化  → ⚠️ 代替カバレッジ無しなら修正要求
+  ├─ CI 失敗 (PR 起因)           → ❌ 修正するまでマージ不可
+  └─ 上記すべてクリア + CI green  → ✅ マージ実行 (下記)
+```
+
+## マージ実行手順 (自律)
+
+> [!IMPORTANT]
+> **CI が green になったら、確認を取らず自律的に squash merge する** (ユーザー standing rule)。意味のない確認で止まらない。
+
+1. worktree で head ブランチを checkout する
+2. `git merge origin/main --no-edit` で最新 main を取り込む
+3. マージ後の diff を再レビューし、**想定外の大量削除 / コンフリクト解決ミスが無いか**確認する
+4. `git push`
+5. CI が全ジョブ green になるまで待つ (`gh pr checks <num>` を監視。green を待たずにマージしない)
+6. `gh pr merge --squash`
+   - **`--admin` / `--no-verify` は使わない** (保護・検証をバイパスしない)
+   - **`--delete-branch` は付けない**
+7. マージ後、primary checkout で `git pull origin main` してローカル main を同期する
+8. 作業 worktree を `git worktree remove` で片付ける
+
+## 部分取り込みパターン
+
+PR の一部だけが有用な場合:
+
+1. 有用な変更だけを cherry-pick or 手動再実装で取り込む
+2. PR にクローズ理由をコメントで明記する
+3. 取り込んだ変更 / 除外した変更を区別して記述する
+

--- a/.agents/skills/core_qa_process/SKILL.md
+++ b/.agents/skills/core_qa_process/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: core_qa_process
+description: CSW (Rust + Tauri v2) の QA・検証プロセスと継続的改善のルールを定義するスキル。コード変更の完了報告前、PR を出す前、機能や修正を「できた」と言う前に発動し、検証順序とエビデンス必須の原則を強制する。
+---
+
+＃ QA・検証と継続的改善
+
+CSW (Rust + Tauri v2 / macOS) で開発した機能・修正を品質低下なく本番 (DMG リリース) に乗せるための検証プロセスと、AI 自身が同じミスを繰り返さないための継続的改善ルール。
+
+> [!CAUTION]
+> **AI は「できた」「PASS」と報告する前に、自分でエビデンスを確認する義務がある。** core/CLI 変更ならコマンド実行結果、GUI 変更ならアプリ起動 + WebView の挙動を一次情報として確認する。サブエージェントの「PASS」報告を鵜呑みにしてはならない。エビデンスなき PASS は虚偽報告と同等。
+
+## 1. 検証の固定順序 (厳守)
+
+コード変更後は**必ずこの順序で**検証する。前段が落ちたら次に進まず、その場で直す。
+
+```
+1. cargo fmt --check
+2. cargo clippy --workspace --all-targets -- -D warnings
+3. cargo build --workspace
+4. cargo test --workspace
+5. (GUI 変更時) cargo tauri dev でアプリ起動 + WebView devtools 確認
+```
+
+- **fmt → clippy → build → test → アプリ起動** の順を崩さない。整形・lint・型/ビルドの機械的エラーを先に潰してから、振る舞いの検証 (test / 実機) に進む。
+- `clippy` は `-D warnings` で警告ゼロが合格条件。`#[allow(...)]` で抑止する場合は理由を `// ALLOW: ` コメントで明記する (modern-rust-workflow 参照)。
+- `cargo fmt --all` は実際に整形する操作。検証は破壊しない `cargo fmt --check` で行い、差分があれば整形してから再検証する。
+
+> [!IMPORTANT]
+> **cargo はローカル環境で使えないことがある。その場合 CI が検証パスの本体になる。** PR を push し、CI の **Test** (`cargo test --workspace --exclude csw-desktop` = core+cli) と **Build** (`cargo build --workspace` = desktop 含む全クレート) の結果ログを一次エビデンスとして確認する。CI のグリーンを確認せずに「通った」と書かない。
+
+## 2. クレート別の検証観点
+
+| クレート | 検証手段 | 観点 |
+|---|---|---|
+| `crates/core` (csw-core) | `cargo test --workspace` / CI Test | ロジック・プロファイル隔離・Keychain (MockKeychainProvider) のユニット/結合テスト |
+| `crates/cli` (csw) | `cargo test` + 実コマンド実行 | 引数解釈・exit code・標準出力/エラー出力の文言 |
+| `crates/desktop` (csw-desktop) | `cargo build --workspace` (CI Build) + `cargo tauri dev` | コンパイル可否 (CI Test からは除外) + 実機でのトレイ/設定 UI 挙動 |
+
+- `csw-desktop` は CI の Test ジョブから除外されている。**desktop のビルド健全性は Build ワークフロー (全ワークスペースビルド) で、振る舞いは `cargo tauri dev` の実機確認でしか担保できない。** test が緑でも desktop が壊れていないことの証明にはならない点に注意。
+
+## 3. GUI 変更時の実機確認 (The QA Agent 視点)
+
+GUI (トレイ / 設定ウィンドウ) を変えたら、`cargo tauri dev` でアプリを起動し、以下を自分で確認する。
+
+- **見た目の確認**: 期待した UI が実際に描画されているか (スクリーンショットを取り、自分で `Read` で開いて確認する)。
+- **WebView devtools のコンソールエラーチェック**: WebView 内で右クリック → Inspect Element (または開発ビルドの devtools) を開き、Console にエラー/警告が出ていないか確認する。フロントエンドの例外は build/test では検出されない。
+- **トレイ常駐の動作**: メニュー項目・クリック・プロファイル切替が期待どおり反応するか。
+- **エビデンスを項目ごとに個別確認する**: 複数箇所を一括修正して「全部 OK」と丸めない。1 項目 1 エビデンス。
+
+## 4. リファクタ・名称変更後の全域確認
+
+名称変更・リファクタリング後は `Grep` でワークスペース全体 (`crates/` / `docs/` / `website/`) を横断検索し、**旧語彙・旧 API の残存がゼロ**であることを確認する。コメント・doc・テスト名・エラーメッセージ・LP の文言まで含めて潰す。
+
+## 5. 継続的改善とフィードバックループ (義務)
+
+発生した問題を単に直すだけでなく、**「なぜ起きたか」「どうすれば AI が同じミスを繰り返さないか」を分析し、規約・スキルへ還元する**。
+
+1. **問題解決後の振り返り**: 複雑な不具合解決や大規模修正の完了後、得られた知見を抽出する。
+2. **ルールの言語化**: 新たなアンチパターンを見つけたら `.agents/skills/` を更新する (または `.agents/AGENTS.md` に追記)。直す前に「汎用化できる教訓か」を毎回明示的に判断する。
+3. **知識の代謝**: 定期的にルールを抽象化・圧縮する。SKILL.md は 1 ファイル 80 行以内を目安に保つ。
+4. **人間の承認ゲート**: 仕様確定 (`docs/SPECIFICATION.md`)、`main` へのマージ、`#[allow(...)]` 追加など不可逆/方針が割れる分岐は、推奨を添えて人間の Approve を求める。
+5. **自己進化**: 各タスクフェーズの終わりに、検証プロセスの非効率やルールの穴がないか自己評価し、改善案を提示する。
+
+## 6. 絶対に譲らない原則
+
+- **セキュリティ・プライバシー・倫理を利便性と引き換えにしない。** 検証を急ぐために Keychain・プロファイル隔離の確認を飛ばさない。
+- **コマンド出力を切り詰めない。** 「…(略)」で要約せず、失敗箇所・テスト結果は全文を確認する。途中で truncate して PASS と判断しない。
+- **検証の偽装をしない。** スクリーンショットに修正が反映されていない / サブエージェントの「確認した」を転記しただけ、は虚偽。AI 自身が一次情報を開いて確かめる。
+
+## 関連スキル
+
+- `core_spec_first_development` (`/spec-first`): 仕様合意 → テスト(RED) → 実装(GREEN) → エビデンス付き検証の順序。
+- `core_bug_fix_protocol` (`/bugfix`): リグレッションテストファースト、プロファイル隔離・並列安全性の検証観点。
+- `core_pr_review_cycle` (`/code-review`): lint/test 全パス後の PR レビューサイクルとマージ基準。
+- `modern-rust-workflow`: clippy `-D warnings`・エラーハンドリング・ワークスペース運用の標準。

--- a/.agents/skills/core_session_handoff/SKILL.md
+++ b/.agents/skills/core_session_handoff/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: core_session_handoff
+description: セッション間の引き継ぎプロトコル。Implementation Plan を docs/proposals/ の git 管理ファイルとしてバトンパスに使い、SPECIFICATION.md / USER_GUIDE は完了状態の記録として使う。新規実装・大幅修正の着手前、またはセッション開始/終了時に発動する。
+---
+
+# セッション引き継ぎプロトコル
+
+CSW (Claude Desktop Switcher / Rust + Tauri v2 macOS app) のセッション間引き継ぎ標準。Implementation Plan を git 管理のバトンパスとして使い、`docs/SPECIFICATION.md` / `docs/USER_GUIDE*.md` は完了状態の記録として使う。Plan のライフサイクル全体を本スキルに統合している。
+
+## ドキュメントの役割分担
+
+| ドキュメント | 目的 | タイミング | 配置 |
+|---|---|---|---|
+| **Implementation Plan** | セッション間のバトンパス + PR レビュー時の背景共有 | 着手前に作成 + ライフサイクルで更新 | `docs/proposals/<slug>.md`（git 管理、frontmatter の `status` で管理） |
+| **`docs/SPECIFICATION.md`** | 仕様の現在地（完了状態の正典 / spec canon） | タスク**完了後**に更新 | `docs/` 直下 |
+| **`docs/USER_GUIDE.md` / `USER_GUIDE_EN.md`** | ユーザー向けガイド（完了状態） | タスク**完了後**に更新 | `docs/` 直下 |
+
+> Plan は「次に何をやるか（前方参照）」、SPECIFICATION / USER_GUIDE は「何が完成したか（後方の記録）」。役割を混同しない。`blueprint.md` は存在しない。仕様の正典は必ず `docs/SPECIFICATION.md`。
+
+## Plan の配置と命名規約
+
+- **ディレクトリ**: `docs/proposals/`（git 管理。worktree ローカルパスには**絶対に置かない** — worktree 削除で消失する）
+- **ファイル名**: `<kebab-case-slug>.md`。中身が分かる英語短縮トピック名。日付はファイル名に付けず、frontmatter の `created` と git 履歴に持たせる
+- **例**: `docs/proposals/cli-env-eval-profile-switch.md` / `docs/proposals/keychain-isolation-per-profile.md`
+
+## Plan の frontmatter（必須）
+
+各 plan ファイルの先頭に以下の YAML frontmatter を必ず記載する：
+
+```yaml
+---
+title: タスクの短いタイトル（50字以内）
+created: YYYY-MM-DD
+status: draft | approved | in-progress | completed | rejected
+pr: 42                     # PR 作成後に番号を追記（未確定時は省略可）
+related_prs: []            # 関連 PR 番号（任意）
+related_issues: []         # 関連 Issue 番号（任意）
+---
+```
+
+### status の遷移
+
+| status | 意味 |
+|---|---|
+| `draft` | 作成中・ユーザ Approve 未取得 |
+| `approved` | ユーザが Approve 済み、実装着手可能 |
+| `in-progress` | PR 作成済み、実装中 |
+| `completed` | PR マージ済み、タスク完了 |
+| `rejected` | PR Close または plan 自体が見送りになった |
+
+遷移は `draft → approved → in-progress → completed`（または途中で `rejected`）。
+
+## Plan のライフサイクル
+
+| ステージ | アクション | commit |
+|---|---|---|
+| 1. ドラフト作成 | `docs/proposals/<slug>.md` を作成、`status: draft` | ✅ する |
+| 2. ユーザ Approve | `status: approved` に更新 | ✅ する |
+| 3. PR 作成 | PR 本文に plan へのリンクを貼り、`status: in-progress` に更新 | ✅ する |
+| 4. 実装中の更新 | 必要に応じて plan を更新（変更履歴は git diff で追える） | ✅ する |
+| 5. PR マージ | `status: completed` に、`pr` フィールドに番号確定 | ✅ する |
+| 6. PR Close | `status: rejected` に、末尾に Close 理由を追記 | ✅ する |
+
+- 「ドラフトだから commit しない」運用はしない。worktree ローカルにのみ置くと worktree 削除で消失し、別セッション・別 PC・別エージェントから参照不能になる。
+- **plan の commit は必ず実装と同じ feature branch に含め、PR で main にマージする。** PR の diff に plan が含まれることで、人間 + Claude のレビュアーが「なぜこの変更が入ったのか」を追える。
+- **main 直接 push は禁止**（branch protection で物理強制）。`status: in-progress → completed` の事後追記・誤字修正・リンク切れ修正など、軽微な変更も含めて plan へのすべての変更は PR 経由。本スキル自体の更新も同様に PR 経由。
+- plan 単体の軽微 PR でも CI green を待ってマージする。`gh pr merge --squash` のみ。`--admin` / `--no-verify` で CI をスキップして例外を作らない。待ち時間が惜しければ軽微更新を実装 PR にまとめる。
+
+## Plan の必須セクション
+
+次セッションが**読むだけで即着手できる**レベルにする。最低限：
+
+1. **背景・本セッションの完了事項**: コンテキスト復元用の最小限の要約
+2. **ゴール**: ユーザ方針と完了条件
+3. **設計原則**: `.agents/AGENTS.md` および既存スキルから適用するルール（特にセキュリティ・プライバシー・倫理を利便性と引き換えにしない、を明記）
+4. **タスク詳細**:
+   - 変更ファイル一覧（テーブル形式。`crates/core` (csw-core / ロジック + テスト) / `crates/cli` (csw-cli) / `crates/desktop` (csw-desktop / Tauri v2) のどこを触るか）
+   - 実装ステップ（番号付きの手順）
+   - 検証計画（下記コマンド）
+5. **リスクと対応**
+6. **スコープ外（混ぜない）**: 別 PR で扱う変更を明示
+7. **完了条件**: チェックリスト形式
+
+### 検証計画に書くコマンド
+
+ローカルに cargo が無い環境があるため、**検証の正典は CI**（実装 → CI で build/test/clippy → fix → 収束、の Workflow フィードバックループで回す）。ローカルで動く場合は同じコマンドを先に流す：
+
+```bash
+cargo fmt --check                                    # フォーマット
+cargo clippy --workspace --all-targets -- -D warnings # lint（warning をエラー扱い）
+cargo build --workspace                              # build（desktop 含む / build.yml 相当）
+cargo test --workspace                               # test（ローカル）
+```
+
+- CI 上では: `test.yml` が `cargo test --workspace --exclude csw-desktop`（core + cli）、`build.yml` が `cargo build --workspace`（desktop 含むワークスペース全体）を実行する。
+- GUI の手動確認が要るタスクのみ: `cargo tauri dev` を検証計画に追記する。
+- edition 2024 前提。npm / Next.js / Supabase / Expo は存在しないので検証計画に書かない。
+
+## PR 連携（必須）
+
+PR 本文の冒頭に必ず plan へのリンクを記載する：
+
+```markdown
+## Plan
+[docs/proposals/<slug>.md](https://github.com/matsumotory/claude-desktop-switcher/blob/main/docs/proposals/<slug>.md)
+
+## Summary
+...
+```
+
+これにより、レビュアー（人間 + Claude）が背景・設計判断・スコープを即座に理解でき、マージ後に `status: completed` へ更新する起点になる。PR レビューは `/code-review` スラッシュコマンド（`--comment` でインライン投稿、`--fix` で修正適用）または Task/Agent サブエージェントで観点別に回す。`/gemini review` は使わない。
+
+## セッション開始時: 読むべきもの
+
+1. **`git fetch origin main`** を最初に必ず実行（ローカル checkout は信用しない）。作業は `.claude/worktrees/<name>` の隔離 worktree で行い、`/tmp` には作らない
+2. `docs/SPECIFICATION.md` — 仕様の現在地・全体コンテキスト
+3. `docs/proposals/` 配下の `status: in-progress` または `status: approved` の plan — 具体的な着手ポイント
+4. `.agents/AGENTS.md` と該当ドメインの `.agents/skills/`（`modern-rust-workflow` / `tauri-v2-best-practices` 等）
+5. セキュリティ確認: `cargo audit`（導入済みなら）または `.github/workflows/security.yml` の結果を確認。脆弱性があればセキュリティ対応を優先する
+
+## セッション終了時のチェックリスト
+
+- [ ] Plan の `status` を実態に合わせて更新（`approved` → `in-progress` → `completed` 等）
+- [ ] 未完了タスクがあれば plan の「実装ステップ」を最新化（次セッションが文脈ゼロから再開できるように）
+- [ ] PR 作成済みなら plan の `pr` フィールドに番号を確定追記
+- [ ] PR 本文に plan へのリンクが貼られていることを確認
+- [ ] CI が green であることを確認してから `gh pr merge --squash` でマージ（自律マージ可）
+- [ ] マージ後、primary checkout で `git pull origin main` を実行し、ローカル main を同期
+
+## アンチパターン
+
+- ❌ Implementation Plan なしで大規模実装に着手 / セッションを終了する（次セッションが文脈ゼロから始まる）
+- ❌ Plan を worktree ローカル（git 管理外）にのみ置く（worktree 削除で消失、別セッション参照不能）
+- ❌ Plan を main に直接 push する（PR の diff に含まれず、branch protection 違反。plan ⇔ 実装の紐付きが失われる）
+- ❌ Plan を作っても PR 本文にリンクを貼らない（レビュアーが背景を追えない）
+- ❌ `docs/SPECIFICATION.md` / `USER_GUIDE` に「次やること」の詳細手順を書く（完了状態の記録のみ。前方参照は plan に書く）
+- ❌ `--admin` / `--no-verify` で CI を飛ばしてマージする（軽微な plan 単体 PR でも禁止）
+- ❌ status を更新せず古い状態で放置 / frontmatter を省略する（plan の信頼性低下・status 集計不能）
+- ❌ 1 plan に複数の独立タスクを詰め込む（PR 1 つにつき plan 1 つを基本とする）
+- ❌ AI 生成の引き継ぎメモ・スクラッチを repo に commit する（scratchpad に留める。`.agents/AGENTS.md` §7 違反）

--- a/.agents/skills/core_worktree_for_derived_tasks/SKILL.md
+++ b/.agents/skills/core_worktree_for_derived_tasks/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: core_worktree_for_derived_tasks
+description: メイン作業から派生したサブタスク (chip 提案 / spawn_task / Agent 委譲 / 別 PR 化したい修正 / 割り込み作業) は、必ず `git worktree add` でリポジトリ階層内の `.claude/worktrees/<name>` を `origin/main` 起点に切り、親 repo の working tree / branch / stash には一切触らない。派生タスクを認識した瞬間 (= 別 PR にしたい / 別観点で並行させたい / 割り込みを頼まれた) に発動する。
+---
+
+# 派生タスクは必ず worktree で切る
+
+CSW (Claude Desktop Switcher) の開発で **メイン作業から派生したサブタスク** は、**必ずリポジトリ階層内の `<repo-root>/.claude/worktrees/<name>` に `git worktree` を切ってから作業する**。親 repo の working tree / branch / stash には一切触らない。worktree は `origin/main` を起点にし、`/tmp/` 配下には絶対に作らない。
+
+これは Rust + Tauri v2 のワークスペース (`crates/core` `crates/cli` `crates/desktop`) を 1 つの作業ツリーで共有しているため特に重要で、派生タスクが親ツリーを切り替えると `cargo` のビルドキャッシュや `cargo tauri dev` の dev-server が巻き込まれる (後述)。
+
+## 1. 派生タスクとは
+
+以下のいずれかに該当する作業:
+- `mcp__ccd_session__spawn_task` (chip 提案)
+- `Agent` (Task) tool 委譲 (`isolation: "worktree"` 指定を含む)
+- 「これは別 PR にした方が良さそう」と判断して別 branch で進めたい修正
+- メイン作業の CI (Test ワークフロー / build.yml) 待ち時間に並行して進めたい関連作業
+- ユーザーに「先に別の小さい修正やって」と頼まれた割り込み作業
+
+メイン作業の scope に収まらない / 別 PR に分けたいと気付いた **その瞬間** に本 skill を発動する。「一旦親ツリーで直してから分ける」は禁止 (親ツリーが汚れて scope 混在 PR になる)。
+
+## 2. なぜ別 worktree が必須か
+
+> [!CAUTION]
+> 派生タスクが親 repo の HEAD / working tree を巻き込むと、未 commit の変更が discard され、Tauri dev-server が過去状態を reload し、cargo の再ビルドが走る。事故の再発防止としてこの運用を strict に守る。
+
+被害の連鎖:
+1. **未 commit の変更が discard** され、再実装が必要になる
+2. **`cargo tauri dev` の file watcher が過去の HEAD を reload** して GUI が壊れたように見える (Tauri v2 は frontend asset と Rust 側の両方を watch しており、親ツリーの branch を切り替えると意図しない rebuild / reload が走る)
+3. **`cargo` のインクリメンタルキャッシュが切り替わって全 rebuild** が発生し、検証が遅くなる
+4. **`git stash` 由来のコンフリクト marker** がファイルに混入し、復旧操作が必要になる
+5. ユーザーの作業集中が切れる
+
+tool 任せにせず **明示的に自分で worktree を切る運用** にすることで、親 repo を物理的に保護する。
+
+## 3. 派生タスクを切るときの基本手順
+
+### 3.1 開始 (pre git state check)
+
+```bash
+# 親 repo の HEAD を確認。必ず commit + push 済みの安定状態にしてから切る
+git status
+git branch --show-current   # 親の branch を記録しておく
+# clean でなければ先に commit + push する (中途半端な状態で worktree を切らない)
+
+# origin/main を最新化してから、それを起点に worktree を作る
+git fetch origin main
+git worktree add -b feat/<topic> .claude/worktrees/<topic> origin/main
+#   ↑ 配置先は必ずリポジトリ階層内の .claude/worktrees/<topic> (/tmp/ 禁止)
+#   ↑ base は必ず origin/main (親の作業 branch から派生させない = scope 混在 PR の防止)
+
+# 親 repo が何も変わっていないことを再確認
+git status
+git branch --show-current   # 開始時に記録した branch のままであること
+```
+
+### 3.2 作業
+
+worktree 内のファイルを編集するときは **絶対パスで指定** し (`.../.claude/worktrees/<topic>/...`)、親の working tree のファイルを誤って触らない。Read / Grep / Edit / Bash の対象パスもすべて worktree 配下に向ける。
+
+```bash
+cd <repo-root>/.claude/worktrees/<topic>
+# ここで編集 → 検証 → commit → push → PR を完結させる
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo build --workspace        # desktop 含むワークスペース全体 (build.yml と同等)
+cargo test --workspace --exclude csw-desktop   # core + cli (test.yml と同等)
+git add ... && git commit -m "..."   # 規約は core_commit_standard
+git push -u origin feat/<topic>
+gh pr create --title "..." --body "..."
+
+# 完了後、親 repo に戻る
+cd <repo-root>
+```
+
+> [!NOTE]
+> `cargo` がローカルで使えない環境では、push 後の CI (Test ワークフロー / build.yml) を一次検証経路とする。CI を Workflow フィードバックループで監視し、緑になるまで修正を回す (core_ai_workflow)。
+
+### 3.3 終了 (cleanup)
+
+PR が CI 緑でマージされたら worktree を撤収する:
+
+```bash
+# 親 dir から
+git worktree remove .claude/worktrees/<topic>
+git branch -D feat/<topic>          # 不要なら branch も削除 (次回 worktree add の衝突防止)
+
+# primary checkout のローカル main を origin/main に同期する
+git pull origin main
+```
+
+撤収を放置すると次回 `worktree add` 時に既存 branch / dir で衝突する。
+
+## 4. tool 経由で派生タスクを出すとき
+
+### 4.1 `Agent` (Task) tool
+
+`isolation: "worktree"` を必ず指定する。指定すれば自動的に worktree が切られ、親に影響しない。委譲先 agent には「対象パスは worktree 配下に限定し、親 checkout を読まない・編集しない」ことを明示する。
+
+### 4.2 `mcp__ccd_session__spawn_task` (chip)
+
+説明文には「session and worktree」を起動すると書かれているが、念のため **使う前後で必ず親 repo の状態を確認する**:
+
+1. `git status` で親 working tree が clean か確認
+2. すべて commit + push して安定状態にする (未 commit / 未 push 変更があれば消失リスク)
+3. spawn 後すぐ `git status` / `git branch --show-current` で親 branch が変わっていないか確認
+4. 親 branch が変わっていたら即座に元 branch へ戻し、失った変更があれば再実装
+
+これらを踏めないなら **`spawn_task` を使わず、自分で `git worktree add` を切って作業する**。
+
+## 5. 並行作業の鉄則 (post git state check)
+
+- **`cargo tauri dev` が動いている最中の派生タスクは特に注意**。親ツリーの branch を切り替えると file watcher が即 reload / rebuild する。worktree なら親の dev-server は元 branch のファイルを見続けるので影響なし。派生作業側で GUI 実機確認が必要なら worktree 内で別途 `cargo tauri dev` を起動する。
+- 派生タスク完了後、親 dir に戻って必ず確認:
+  - `git status` (何も変わっていない)
+  - `git branch --show-current` (開始時に記録した branch のまま)
+  - `git stash list` (新しい stash が増えていない。増えていたら内容を確認してから扱う)
+  - `git reflog -10` (想定外の reset / checkout がない)
+- worktree は親と `.git` を共有するため、派生タスクが作った stash は親でも見える。内容を確認せず drop しない。
+
+## 6. 反例 (やってはいけないこと)
+
+- 親 working tree で `git stash` + `git checkout other-branch` で派生作業する (元 branch の `cargo tauri dev` が切り替わり rebuild / reload が走る)
+- `spawn_task` を未 commit 変更がある状態で起動する (変更消失リスク)
+- worktree を `/tmp/` 配下に作る (`.claude/settings.json` が継承されず auto モード / hooks が効かない)
+- worktree 内から親 dir のファイルを編集する (隔離の意味がなくなる)
+- worktree を親の作業 branch から派生させる (必ず `origin/main` 起点。そうでないと scope 混在 PR になる)
+- `main` へ直接 push / 直接マージする (必ず PR 経由。CI 緑が前提)
+- PR マージ後に worktree / branch を撤収せず放置する
+
+## 7. 関連 skill
+
+- [`core_ai_workflow`](../core_ai_workflow/SKILL.md): Workflow / Agent による多段委譲と CI フィードバックループ
+- [`core_pr_review_cycle`](../core_pr_review_cycle/SKILL.md): PR レビュー運用 (派生 PR も同じ流れ)
+- [`core_commit_standard`](../core_commit_standard/SKILL.md): commit メッセージ規約
+- [`modern-rust-workflow`](../modern-rust-workflow/SKILL.md): cargo fmt / clippy / test の検証規律
+- [`core_spec_first_development`](../core_spec_first_development/SKILL.md): 仕様正典は `docs/SPECIFICATION.md`、セッション計画は `docs/proposals/`

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ Cargo.lock
 *.swp
 *.swo
 
+# Claude Code session worktrees (per-session isolated worktrees live here)
+.claude/worktrees/
+
 # Tauri (Phase 2)
 /crates/tauri-app/dist/
 /crates/tauri-app/node_modules/

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,9 @@
+# Implementation Plans (Proposals)
+
+セッション間のバトンパス用 Implementation Plan を置くディレクトリ。運用は [`core_session_handoff`](../../.agents/skills/core_session_handoff/SKILL.md) を参照。
+
+- ファイル名: `<kebab-case-slug>.md`（日付はファイル名に付けず frontmatter と git 履歴で持つ）
+- 各 plan の先頭に frontmatter（`title` / `created` / `status` / `pr`）を必須で付ける
+- `status` は `draft → approved → in-progress → completed / rejected` で遷移させ、各段階で commit する
+- Plan は「次に何をやるか（前方参照）」、`docs/SPECIFICATION.md` は「何が完成したか（完了状態の正典）」。役割を混同しない
+- Plan も実装と同じ feature ブランチ + PR 経由で更新する（`main` 直 push 禁止）


### PR DESCRIPTION
## 概要
houlens / gaishokulens / 研究リポで実戦検証済みの **worktree 隔離 + 多エージェント + workflow フィードバックループ + safe-ops** の開発手法を、Rust/Tauri の CSW 向けに適応して移植（引き継ぎ Section 2 / item 2）。dynamic workflow で houlens の各スキルを並列に読み込み、CSW 文脈へ書き換えた。

## 新規スキル（`.agents/skills/`）
| スキル | 役割 |
|---|---|
| `core_worktree_for_derived_tasks` | 派生タスクは必ず別 worktree に隔離（親ツリー保護、Tauri dev-server reload 事故防止） |
| `core_session_handoff` | `docs/proposals/` の Plan でセッション間バトンパス（frontmatter + status 遷移） |
| `core_ci_hang_recovery` | CI ハング時の cancel→completed 待ち→rerun |
| `core_qa_process` | `fmt→clippy→build→test→起動目視` の検証順序とエビデンス義務 |
| `core_pr_merge_checklist` | スコープ厳守・安全装置緩和検出・マージ判定フロー |
| `core_agent_roles` | Architect/Core/Desktop/Documenter/QA のロール分担 |

## その他
- `AGENTS.md` に **Skill トリガーテーブル**を追加（条件 → スキル自動ロード）。
- `.gitignore` に `.claude/worktrees/` を追加（worktree のコミット汚染防止）。
- `docs/proposals/README.md` で Implementation Plan 運用規約を明文化。

製品コードは非変更（docs/skills のみ）。CI green 確認後に自律マージ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)