### PR TITLE
fix(core): linker が実 default データを破壊的削除しないようガード

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -29,6 +29,9 @@ pub enum CswError {
     #[error("Existing file would be overwritten (non-destructive violation): {0}")]
     NonDestructiveViolation(String),
 
+    #[error("Refused to delete '{0}': path lies inside the real Claude default data directory")]
+    RefusedDefaultDataDeletion(String),
+
     #[error("Platform not supported: {0}")]
     UnsupportedPlatform(String),
 

--- a/crates/core/src/profile/linker.rs
+++ b/crates/core/src/profile/linker.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use crate::error::Result;
+use crate::error::{CswError, Result};
 use crate::platform::PlatformProvider;
 use crate::profile::{Profile, SharingMode};
 
@@ -142,13 +142,38 @@ impl<'a> Linker<'a> {
                 if self.provider.is_symlink(&path) {
                     self.provider.remove_symlink(&path)?;
                 } else if path.is_file() {
+                    self.assert_safe_to_delete(&path)?;
                     fs::remove_file(&path)?;
                 } else if path.is_dir() {
+                    self.assert_safe_to_delete(&path)?;
                     fs::remove_dir_all(&path)?;
                 }
             }
         }
 
+        Ok(())
+    }
+
+    /// Refuse destructive operations on the user's real default Claude data.
+    ///
+    /// Profiles other than "default" always live under their own per-profile
+    /// directories, so the linker should never delete anything inside the real
+    /// default Desktop/CLI dirs. This guard is defense-in-depth: if a profile is
+    /// ever misconfigured (or a future change resolves a target into the default
+    /// dir), refuse rather than wipe the user's environment.
+    fn assert_safe_to_delete(&self, path: &Path) -> Result<()> {
+        let defaults = [
+            self.provider.claude_desktop_default_dir(),
+            self.provider.claude_cli_default_dir(),
+        ];
+        if defaults
+            .iter()
+            .any(|root| path == root.as_path() || path.starts_with(root))
+        {
+            return Err(CswError::RefusedDefaultDataDeletion(
+                path.display().to_string(),
+            ));
+        }
         Ok(())
     }
 
@@ -166,6 +191,7 @@ impl<'a> Linker<'a> {
             // Keep existing files if they were manually created or copies,
             // but if we are switching to Share, we must clear them.
             if mode == SharingMode::Share {
+                self.assert_safe_to_delete(target)?;
                 if target.is_file() {
                     fs::remove_file(target)?;
                 } else {
@@ -224,5 +250,133 @@ impl<'a> Linker<'a> {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::mock::MockPlatformProvider;
+    use crate::profile::{IsolationConfig, ProfileMeta, SharingConfig};
+    use std::fs;
+    use tempfile::tempdir;
+
+    /// The linker must never destroy the user's real default Claude data.
+    /// Even if a profile is (mis)configured so its isolation directories point
+    /// straight at the real default dirs, `unlink_profile` must refuse to delete
+    /// anything inside them rather than wiping the user's environment.
+    #[test]
+    fn unlink_profile_refuses_to_delete_real_default_data() {
+        let desktop_dir = tempdir().unwrap();
+        let cli_dir = tempdir().unwrap();
+        let app_dir = tempdir().unwrap();
+
+        // Real user memory living in the default CLI dir.
+        let projects = cli_dir.path().join("projects");
+        fs::create_dir_all(&projects).unwrap();
+        let memory = projects.join("important.md");
+        fs::write(&memory, "real user memory").unwrap();
+
+        let provider = MockPlatformProvider::new(
+            desktop_dir.path().to_path_buf(),
+            cli_dir.path().to_path_buf(),
+            app_dir.path().to_path_buf(),
+        );
+
+        // Profile whose isolation dirs ARE the real default dirs.
+        let profile = Profile {
+            profile: ProfileMeta {
+                name: "danger".to_string(),
+                icon: String::new(),
+                color: String::new(),
+                is_default: false,
+            },
+            isolation: IsolationConfig {
+                desktop_user_data_dir: desktop_dir.path().to_path_buf(),
+                cli_config_dir: cli_dir.path().to_path_buf(),
+            },
+            sharing: SharingConfig::default(),
+        };
+
+        let linker = Linker::new(&provider);
+        let result = linker.unlink_profile(&profile);
+
+        assert!(
+            result.is_err(),
+            "unlink_profile must refuse to operate on the real default data dirs"
+        );
+        assert!(
+            memory.exists(),
+            "real user data inside the default dir must never be deleted"
+        );
+    }
+
+    /// `apply_link` in Share mode clears a pre-existing non-symlink target
+    /// before linking. That clear must also refuse to touch the real default
+    /// dirs (the most dangerous remove_dir_all path).
+    #[test]
+    fn apply_link_share_refuses_to_clear_real_default_dir() {
+        let desktop_dir = tempdir().unwrap();
+        let cli_dir = tempdir().unwrap();
+        let app_dir = tempdir().unwrap();
+
+        // Real user plugins dir in the default CLI location.
+        let plugins = cli_dir.path().join("plugins");
+        fs::create_dir_all(&plugins).unwrap();
+        let plugin = plugins.join("real_plugin.js");
+        fs::write(&plugin, "// real").unwrap();
+
+        // A source elsewhere to share from.
+        let source_dir = tempdir().unwrap();
+        let source_plugins = source_dir.path().join("plugins");
+        fs::create_dir_all(&source_plugins).unwrap();
+
+        let provider = MockPlatformProvider::new(
+            desktop_dir.path().to_path_buf(),
+            cli_dir.path().to_path_buf(),
+            app_dir.path().to_path_buf(),
+        );
+
+        let linker = Linker::new(&provider);
+        let result = linker.apply_link(&source_plugins, &plugins, SharingMode::Share, true);
+
+        assert!(
+            result.is_err(),
+            "apply_link must refuse to clear a real default directory"
+        );
+        assert!(plugin.exists(), "real user plugin must survive");
+    }
+
+    /// The guard must not break the normal case: deleting a genuine per-profile
+    /// directory (outside the default dirs) still works.
+    #[test]
+    fn apply_link_share_clears_non_default_target() {
+        let desktop_dir = tempdir().unwrap();
+        let cli_dir = tempdir().unwrap();
+        let app_dir = tempdir().unwrap();
+        let profile_dir = tempdir().unwrap();
+
+        // A per-profile target dir (NOT under the default dirs).
+        let target = profile_dir.path().join("plugins");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("old.js"), "// stale").unwrap();
+
+        let source_dir = tempdir().unwrap();
+        let source_plugins = source_dir.path().join("plugins");
+        fs::create_dir_all(&source_plugins).unwrap();
+
+        let provider = MockPlatformProvider::new(
+            desktop_dir.path().to_path_buf(),
+            cli_dir.path().to_path_buf(),
+            app_dir.path().to_path_buf(),
+        );
+
+        let linker = Linker::new(&provider);
+        linker
+            .apply_link(&source_plugins, &target, SharingMode::Share, true)
+            .expect("clearing a non-default profile dir must succeed");
+
+        // After Share, the target becomes a symlink to the source.
+        assert!(provider.is_symlink(&target));
     }
 }


### PR DESCRIPTION
## 概要

`linker` の破壊的削除経路に、ユーザーの**実 default データディレクトリ**(`~/.claude` / `~/Library/Application Support/Claude`)を絶対に消さないためのガードを追加する。引き継ぎの残コード安全課題(item 4)への対応。

## 問題

`Linker::apply_link`(Share モード)と `Linker::unlink_profile` は、対象が symlink でなく実体のファイル/ディレクトリだった場合に `fs::remove_file` / `fs::remove_dir_all` で削除する:

- `unlink_profile`: `projects` / `plugins` / `skills` / `sessions` 等を `remove_dir_all`
- `apply_link`(Share): 既存の非 symlink ターゲットを `remove_dir_all` してから symlink を張る

もしプロファイルの `isolation.cli_config_dir` / `desktop_user_data_dir` が実 default を指す状態(設定不整合・将来のパス解決変更・バグ)になると、ユーザーの実データを消去しうる。現状は `create` / `clone` が default を target に拒否しているため通常運用では発火しないが、**データ消失は不可逆**であり防御層を入れる価値が高い。

## 対応

破壊的削除の直前に `assert_safe_to_delete(path)` を通し、`path` が `claude_desktop_default_dir()` / `claude_cli_default_dir()` 配下(または一致)なら削除せず `CswError::RefusedDefaultDataDeletion` を返す。

- パス判定は `Path::starts_with`(コンポーネント単位)なので `~/.context-switcher-claude` が `~/.claude` に誤マッチしない
- symlink の除去(`remove_symlink`)は実データを失わないためガード対象外。ガードは実体の `remove_file` / `remove_dir_all` のみに適用

## テスト(RED -> GREEN)

`crates/core/src/profile/linker.rs` にユニットテスト 3 件:

1. `unlink_profile_refuses_to_delete_real_default_data` — isolation が実 default を指すプロファイルで `unlink_profile` がエラーを返し、実データが残ることを検証
2. `apply_link_share_refuses_to_clear_real_default_dir` — Share の clear が実 default を消さないことを検証
3. `apply_link_share_clears_non_default_target` — 非 default の専用ディレクトリは従来どおり clear して symlink 化できる回帰防止

## 検証

- `cargo test --workspace --exclude csw-desktop`: PASS(追加 3 件含む)
- 追加コードは `cargo clippy -p csw-core`(新規警告なし)・`cargo fmt --check`(差分なし)を確認

## スコープ外(別途検討)

- `create_symlink` の delete-then-create 非アトミック性(create/clone 時のみ・低リスク)
- プロファイル名のパストラバーサル(`profiles_dir.join(name)`)の入力検証
