### PR TITLE
ci(release): リリース PR の自動マージを廃止し手動マージに分離

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,16 +23,6 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      - name: Enable auto-merge for release PR
-        if: ${{ steps.release.outputs.pr != '' }}
-        run: |
-          PR_NUMBER=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.number')
-          if [ "$PR_NUMBER" != "null" ] && [ -n "$PR_NUMBER" ]; then
-            gh pr merge --auto --merge "$PR_NUMBER" -R "${{ github.repository }}"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-
   build-mac-dmg:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}


### PR DESCRIPTION
## 概要

`release.yml` の「Enable auto-merge for release PR」ステップを廃止し、公開リリースを **release PR の手動マージ**で明示的にトリガーする方式へ分離する。

## 動機

このステップは main への push 毎に release-please の release PR へ auto-merge を arm していた。そのため dependabot 等の無関係なマージで main が進むと release PR が mergeable 化し、**初回公開リリースが無監視で自動発火しうる**結合になっていた。公開リリースは不可逆(タグ / GitHub Release 作成 + 署名済み DMG の公開)であり、意図的・監視下で行うべき。

## 変更

- `release.yml` から auto-merge ステップを削除(release-please の PR 作成 / 更新と build-mac-dmg は従来どおり自動)

## 影響

- リリースを切るには release PR を手動でマージする(1 操作)。それ以外の自動化(changelog / version bump / 署名 DMG ビルド)は不変。
- dependabot 等の通常マージがリリースを誘発しなくなる。
