### PR TITLE
ci(lint): clippy/fmt を CI で強制し既存の lint/format 債務を解消

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    name: Clippy and rustfmt
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # The toolchain version and the clippy/rustfmt components are pinned by
+      # rust-toolchain.toml, which rustup auto-installs on first cargo use.
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy (deny warnings)
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
 use clap::{Parser, Subcommand};
 use colored::*;
 use csw_core::platform::create_provider;
 use csw_core::profile::{ProfileManager, SharingConfig, SharingMode};
 use csw_core::switcher::ContextSwitcher;
+use std::sync::Arc;
 
 #[derive(Parser)]
 #[command(name = "csw")]
@@ -29,7 +29,7 @@ enum Commands {
     Switch {
         /// Profile name to switch to
         name: String,
-        
+
         /// Do not launch Claude Desktop after switching
         #[arg(long)]
         no_launch: bool,
@@ -71,7 +71,7 @@ enum ProfileAction {
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    
+
     // Create platform provider
     let provider: Arc<dyn csw_core::platform::PlatformProvider> = Arc::from(create_provider()?);
 
@@ -80,16 +80,31 @@ fn main() -> anyhow::Result<()> {
             println!("{}", "Initializing Claude Desktop Switcher...".bold());
             let manager = ProfileManager::new(provider.clone())?;
             println!("{} Base configuration created.", "✔".green());
-            println!("{} Profiles directory: {:?}", "✔".green(), provider.app_data_dir().join("profiles"));
-            println!("{} Active profile is: {}", "✔".green(), manager.active_profile_name().cyan());
-            println!("\nRun '{}' to see available profiles.", "csw profile list".yellow());
+            println!(
+                "{} Profiles directory: {:?}",
+                "✔".green(),
+                provider.app_data_dir().join("profiles")
+            );
+            println!(
+                "{} Active profile is: {}",
+                "✔".green(),
+                manager.active_profile_name().cyan()
+            );
+            println!(
+                "\nRun '{}' to see available profiles.",
+                "csw profile list".yellow()
+            );
         }
         Commands::Profile { action } => {
             let manager = ProfileManager::new(provider.clone())?;
             match action {
                 ProfileAction::Create { name, mode } => {
-                    println!("Creating profile '{}' with preset '{}'...", name.cyan(), mode.bold());
-                    
+                    println!(
+                        "Creating profile '{}' with preset '{}'...",
+                        name.cyan(),
+                        mode.bold()
+                    );
+
                     let mut sharing = SharingConfig::default();
                     if mode == "share" {
                         sharing.desktop_config = SharingMode::Share;
@@ -98,12 +113,30 @@ fn main() -> anyhow::Result<()> {
                         sharing.cli_plugins = SharingMode::Share;
                         sharing.desktop_worktrees = SharingMode::Share;
                     } // Else keep defaults (Isolate)
-                    
+
                     match manager.create_profile(&name, sharing, None) {
                         Ok(_) => {
-                            println!("{} Profile '{}' created successfully!", "✔".green(), name.cyan());
-                            println!("  Desktop Data: {:?}", provider.app_data_dir().join("profiles").join(&name).join("desktop-data"));
-                            println!("  CLI Data: {:?}", provider.app_data_dir().join("profiles").join(&name).join("cli-data"));
+                            println!(
+                                "{} Profile '{}' created successfully!",
+                                "✔".green(),
+                                name.cyan()
+                            );
+                            println!(
+                                "  Desktop Data: {:?}",
+                                provider
+                                    .app_data_dir()
+                                    .join("profiles")
+                                    .join(&name)
+                                    .join("desktop-data")
+                            );
+                            println!(
+                                "  CLI Data: {:?}",
+                                provider
+                                    .app_data_dir()
+                                    .join("profiles")
+                                    .join(&name)
+                                    .join("cli-data")
+                            );
                         }
                         Err(e) => {
                             eprintln!("{} Failed to create profile: {}", "✘".red(), e);
@@ -117,40 +150,47 @@ fn main() -> anyhow::Result<()> {
                     println!("{}", "Available profiles:".bold());
                     for name in profiles {
                         if name == active {
-                            println!("  {} {} {}", "*".green().bold(), name.green().bold(), "(active)".green());
+                            println!(
+                                "  {} {} {}",
+                                "*".green().bold(),
+                                name.green().bold(),
+                                "(active)".green()
+                            );
                         } else {
                             println!("    {}", name);
                         }
                     }
                 }
-                ProfileAction::Show { name } => {
-                    match manager.get_profile(&name) {
-                        Ok(p) => {
-                            println!("{}: {}", "Profile".bold(), p.profile.name.cyan());
-                            println!("  Icon: {}", p.profile.icon);
-                            println!("  Color: {}", p.profile.color);
-                            println!("  Is Default: {}", p.profile.is_default);
-                            println!("  Desktop Path: {:?}", p.isolation.desktop_user_data_dir);
-                            println!("  CLI Path: {:?}", p.isolation.cli_config_dir);
-                            println!("  Sharing Configurations:");
-                            println!("    Desktop Config (MCP): {:?}", p.sharing.desktop_config);
-                            println!("    CLI Settings: {:?}", p.sharing.cli_settings);
-                            println!("    CLAUDE.md (Rules): {:?}", p.sharing.cli_claude_md);
-                            println!("    CLI Project Memory: {:?}", p.sharing.cli_project_memory);
-                            println!("    CLI Plugins: {:?}", p.sharing.cli_plugins);
-                            println!("    Desktop Worktrees: {:?}", p.sharing.desktop_worktrees);
-                            println!("    Desktop Device ID: {:?}", p.sharing.desktop_device_id);
-                        }
-                        Err(e) => {
-                            eprintln!("{} Failed to find profile '{}': {}", "✘".red(), name, e);
-                            std::process::exit(1);
-                        }
+                ProfileAction::Show { name } => match manager.get_profile(&name) {
+                    Ok(p) => {
+                        println!("{}: {}", "Profile".bold(), p.profile.name.cyan());
+                        println!("  Icon: {}", p.profile.icon);
+                        println!("  Color: {}", p.profile.color);
+                        println!("  Is Default: {}", p.profile.is_default);
+                        println!("  Desktop Path: {:?}", p.isolation.desktop_user_data_dir);
+                        println!("  CLI Path: {:?}", p.isolation.cli_config_dir);
+                        println!("  Sharing Configurations:");
+                        println!("    Desktop Config (MCP): {:?}", p.sharing.desktop_config);
+                        println!("    CLI Settings: {:?}", p.sharing.cli_settings);
+                        println!("    CLAUDE.md (Rules): {:?}", p.sharing.cli_claude_md);
+                        println!("    CLI Project Memory: {:?}", p.sharing.cli_project_memory);
+                        println!("    CLI Plugins: {:?}", p.sharing.cli_plugins);
+                        println!("    Desktop Worktrees: {:?}", p.sharing.desktop_worktrees);
+                        println!("    Desktop Device ID: {:?}", p.sharing.desktop_device_id);
                     }
-                }
+                    Err(e) => {
+                        eprintln!("{} Failed to find profile '{}': {}", "✘".red(), name, e);
+                        std::process::exit(1);
+                    }
+                },
                 ProfileAction::Delete { name } => {
                     println!("Deleting profile '{}'...", name.cyan());
                     match manager.delete_profile(&name) {
-                        Ok(_) => println!("{} Profile '{}' deleted successfully.", "✔".green(), name.cyan()),
+                        Ok(_) => println!(
+                            "{} Profile '{}' deleted successfully.",
+                            "✔".green(),
+                            name.cyan()
+                        ),
                         Err(e) => {
                             eprintln!("{} Failed to delete profile: {}", "✘".red(), e);
                             std::process::exit(1);
@@ -162,14 +202,14 @@ fn main() -> anyhow::Result<()> {
         Commands::Switch { name, no_launch } => {
             let manager = Arc::new(ProfileManager::new(provider.clone())?);
             let switcher = ContextSwitcher::new(provider.clone(), manager.clone());
-            
+
             println!("Switching to profile '{}'...", name.cyan());
             match switcher.switch_to(&name) {
                 Ok(_) => {
                     println!("{} Switched successfully.", "✔".green());
-                    
+
                     let profile = manager.get_profile(&name)?;
-                    
+
                     // Shell environment tip
                     println!("\n{}", "To update your terminal context, run:".bold());
                     println!("  {}", format!("eval $(csw env {})", name).yellow());
@@ -177,7 +217,9 @@ fn main() -> anyhow::Result<()> {
                     // Launch Desktop if requested and not default/disabled
                     if !no_launch && name != "default" {
                         println!("\nLaunching Claude Desktop for '{}'...", name.cyan());
-                        if let Err(e) = csw_core::switcher::desktop::launch_desktop(&profile, provider.as_ref()) {
+                        if let Err(e) =
+                            csw_core::switcher::desktop::launch_desktop(&profile, provider.as_ref())
+                        {
                             eprintln!("{} Failed to launch Claude Desktop: {}", "⚠".yellow(), e);
                         } else {
                             println!("{} Claude Desktop launched.", "✔".green());
@@ -199,7 +241,10 @@ fn main() -> anyhow::Result<()> {
                     print!("{}", script);
                 }
                 Err(e) => {
-                    eprintln!("# Error: Failed to generate env for '{}': {}", profile_name, e);
+                    eprintln!(
+                        "# Error: Failed to generate env for '{}': {}",
+                        profile_name, e
+                    );
                     std::process::exit(1);
                 }
             }
@@ -211,20 +256,31 @@ fn main() -> anyhow::Result<()> {
 
             println!("{}: {}", "Active Profile".bold(), active_name.cyan().bold());
             println!("  CLI Config Dir: {:?}", profile.isolation.cli_config_dir);
-            println!("  Desktop User Data Dir: {:?}", profile.isolation.desktop_user_data_dir);
-            
+            println!(
+                "  Desktop User Data Dir: {:?}",
+                profile.isolation.desktop_user_data_dir
+            );
+
             // Check running status of Claude Desktop
             match provider.is_claude_desktop_running() {
                 Ok(running) => {
                     if running {
                         let pids = provider.claude_desktop_pids().unwrap_or_default();
-                        println!("  Claude Desktop: {} (PIDs: {:?})", "RUNNING".green().bold(), pids);
+                        println!(
+                            "  Claude Desktop: {} (PIDs: {:?})",
+                            "RUNNING".green().bold(),
+                            pids
+                        );
                     } else {
                         println!("  Claude Desktop: {}", "STOPPED".yellow());
                     }
                 }
                 Err(e) => {
-                    println!("  Claude Desktop: {} (error checking status: {})", "UNKNOWN".red(), e);
+                    println!(
+                        "  Claude Desktop: {} (error checking status: {})",
+                        "UNKNOWN".red(),
+                        e
+                    );
                 }
             }
         }
@@ -232,4 +288,3 @@ fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
-

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -17,7 +17,6 @@ pub enum CswError {
     #[error("Active profile '{0}' cannot be deleted. Switch to another profile first.")]
     ActiveProfileCannotBeDeleted(String),
 
-
     #[error("Symlink creation failed: {source} -> {target}")]
     SymlinkFailed {
         source: String,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,4 +3,3 @@ pub mod platform;
 pub mod profile;
 pub mod switcher;
 pub mod watcher;
-

--- a/crates/core/src/platform/macos.rs
+++ b/crates/core/src/platform/macos.rs
@@ -8,6 +8,12 @@ pub struct MacOsProvider {
     home_dir: PathBuf,
 }
 
+impl Default for MacOsProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MacOsProvider {
     pub fn new() -> Self {
         Self {
@@ -18,8 +24,7 @@ impl MacOsProvider {
 
 impl PlatformProvider for MacOsProvider {
     fn claude_desktop_default_dir(&self) -> PathBuf {
-        self.home_dir
-            .join("Library/Application Support/Claude")
+        self.home_dir.join("Library/Application Support/Claude")
     }
 
     fn claude_cli_default_dir(&self) -> PathBuf {
@@ -82,7 +87,11 @@ impl PlatformProvider for MacOsProvider {
         path.is_symlink()
     }
 
-    fn launch_claude_desktop(&self, user_data_dir: &Path, cli_config_dir: Option<&Path>) -> Result<()> {
+    fn launch_claude_desktop(
+        &self,
+        user_data_dir: &Path,
+        cli_config_dir: Option<&Path>,
+    ) -> Result<()> {
         let app_path = self.claude_desktop_app_path();
         if !app_path.exists() {
             return Err(CswError::DesktopNotInstalled);
@@ -90,16 +99,16 @@ impl PlatformProvider for MacOsProvider {
 
         let mut cmd = Command::new("open");
         cmd.arg("-n").arg("-a").arg(&app_path);
-        
+
         if let Some(cli_dir) = cli_config_dir {
             cmd.arg("--env")
-               .arg(format!("CLAUDE_CONFIG_DIR={}", cli_dir.display()));
+                .arg(format!("CLAUDE_CONFIG_DIR={}", cli_dir.display()));
         }
 
         cmd.arg("--args")
-           .arg(format!("--user-data-dir={}", user_data_dir.display()))
-           .spawn()
-           .map_err(|e| CswError::Other(format!("Failed to launch Claude Desktop: {e}")))?;
+            .arg(format!("--user-data-dir={}", user_data_dir.display()))
+            .spawn()
+            .map_err(|e| CswError::Other(format!("Failed to launch Claude Desktop: {e}")))?;
 
         Ok(())
     }
@@ -135,17 +144,21 @@ mod tests {
     fn test_default_paths() {
         let provider = MacOsProvider::new();
         let desktop_dir = provider.claude_desktop_default_dir();
-        assert!(desktop_dir
-            .to_string_lossy()
-            .contains("Application Support/Claude"));
+        assert!(
+            desktop_dir
+                .to_string_lossy()
+                .contains("Application Support/Claude")
+        );
 
         let cli_dir = provider.claude_cli_default_dir();
         assert!(cli_dir.to_string_lossy().ends_with(".claude"));
 
         let app_data = provider.app_data_dir();
-        assert!(app_data
-            .to_string_lossy()
-            .ends_with(".context-switcher-claude"));
+        assert!(
+            app_data
+                .to_string_lossy()
+                .ends_with(".context-switcher-claude")
+        );
     }
 
     #[test]
@@ -192,7 +205,10 @@ mod tests {
         ));
 
         // Verify existing file was not modified
-        assert_eq!(std::fs::read_to_string(&existing).unwrap(), "do not overwrite");
+        assert_eq!(
+            std::fs::read_to_string(&existing).unwrap(),
+            "do not overwrite"
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/core/src/platform/mock.rs
+++ b/crates/core/src/platform/mock.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
 use crate::error::Result;
 use crate::platform::PlatformProvider;
+use std::path::PathBuf;
 
 pub struct MockPlatformProvider {
     pub desktop_default: PathBuf,
@@ -35,7 +35,11 @@ impl PlatformProvider for MockPlatformProvider {
         self.app_data.clone()
     }
 
-    fn create_symlink(&self, target_path: &std::path::Path, link_path: &std::path::Path) -> Result<()> {
+    fn create_symlink(
+        &self,
+        target_path: &std::path::Path,
+        link_path: &std::path::Path,
+    ) -> Result<()> {
         #[cfg(unix)]
         std::os::unix::fs::symlink(target_path, link_path)?;
         #[cfg(windows)]
@@ -49,10 +53,16 @@ impl PlatformProvider for MockPlatformProvider {
     }
 
     fn is_symlink(&self, path: &std::path::Path) -> bool {
-        path.symlink_metadata().map(|m| m.file_type().is_symlink()).unwrap_or(false)
+        path.symlink_metadata()
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false)
     }
 
-    fn launch_claude_desktop(&self, _user_data_dir: &std::path::Path, _cli_config_dir: Option<&std::path::Path>) -> Result<()> {
+    fn launch_claude_desktop(
+        &self,
+        _user_data_dir: &std::path::Path,
+        _cli_config_dir: Option<&std::path::Path>,
+    ) -> Result<()> {
         Ok(())
     }
 

--- a/crates/core/src/platform/mod.rs
+++ b/crates/core/src/platform/mod.rs
@@ -1,9 +1,6 @@
 #[cfg(target_os = "macos")]
 pub mod macos;
 
-#[cfg(target_os = "windows")]
-pub mod windows;
-
 use std::path::PathBuf;
 
 use crate::error::Result;
@@ -33,8 +30,11 @@ pub trait PlatformProvider: Send + Sync {
     /// Create a symbolic link from `link_path` pointing to `target_path`.
     /// The link_path is in the NEW profile directory.
     /// The target_path is the EXISTING file/directory to share.
-    fn create_symlink(&self, target_path: &std::path::Path, link_path: &std::path::Path)
-        -> Result<()>;
+    fn create_symlink(
+        &self,
+        target_path: &std::path::Path,
+        link_path: &std::path::Path,
+    ) -> Result<()>;
 
     /// Remove a symbolic link. Errors if the path is not a symlink.
     fn remove_symlink(&self, link_path: &std::path::Path) -> Result<()>;
@@ -45,7 +45,11 @@ pub trait PlatformProvider: Send + Sync {
     // --- Process control ---
 
     /// Launch Claude Desktop with a specific user-data-dir.
-    fn launch_claude_desktop(&self, user_data_dir: &std::path::Path, cli_config_dir: Option<&std::path::Path>) -> Result<()>;
+    fn launch_claude_desktop(
+        &self,
+        user_data_dir: &std::path::Path,
+        cli_config_dir: Option<&std::path::Path>,
+    ) -> Result<()>;
 
     /// Check if Claude Desktop is currently running.
     fn is_claude_desktop_running(&self) -> Result<bool>;
@@ -61,12 +65,7 @@ pub fn create_provider() -> Result<Box<dyn PlatformProvider>> {
         Ok(Box::new(macos::MacOsProvider::new()))
     }
 
-    #[cfg(target_os = "windows")]
-    {
-        Ok(Box::new(windows::WindowsProvider::new()))
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(not(target_os = "macos"))]
     {
         Err(crate::error::CswError::UnsupportedPlatform(
             std::env::consts::OS.to_string(),

--- a/crates/core/src/profile/config.rs
+++ b/crates/core/src/profile/config.rs
@@ -64,10 +64,10 @@ pub fn list_profile_names(profiles_dir: &Path) -> Result<Vec<String>> {
         let entry = entry?;
         if entry.file_type()?.is_dir() {
             let profile_toml = entry.path().join("profile.toml");
-            if profile_toml.exists() {
-                if let Some(name) = entry.file_name().to_str() {
-                    names.push(name.to_string());
-                }
+            if profile_toml.exists()
+                && let Some(name) = entry.file_name().to_str()
+            {
+                names.push(name.to_string());
             }
         }
     }

--- a/crates/core/src/profile/mod.rs
+++ b/crates/core/src/profile/mod.rs
@@ -5,25 +5,21 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
 use crate::error::{CswError, Result};
+use serde::{Deserialize, Serialize};
 
 /// Sharing mode for a configuration component.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum SharingMode {
     /// Fully isolated: new profile gets its own independent copy.
+    #[default]
     Isolate,
     /// Shared via symlink to the source profile's file/directory.
     Share,
     /// One-time copy from the source (diverges after creation).
     Copy,
-}
-
-impl Default for SharingMode {
-    fn default() -> Self {
-        Self::Isolate
-    }
 }
 
 /// A profile representing a Claude account environment.
@@ -159,7 +155,7 @@ impl ProfileManager {
     pub fn new(provider: Arc<dyn crate::platform::PlatformProvider>) -> Result<Self> {
         let app_data_dir = provider.app_data_dir();
         let app_config_path = app_data_dir.join("config.toml");
-        
+
         let app_config = if app_config_path.exists() {
             config::AppConfig::load(&app_config_path)?
         } else {
@@ -228,7 +224,12 @@ impl ProfileManager {
         config::load_profile(&profile_toml)
     }
 
-    pub fn create_profile(&self, name: &str, sharing: SharingConfig, icon: Option<String>) -> Result<Profile> {
+    pub fn create_profile(
+        &self,
+        name: &str,
+        sharing: SharingConfig,
+        icon: Option<String>,
+    ) -> Result<Profile> {
         if name == "default" {
             return Err(CswError::ProfileAlreadyExists("default".to_string()));
         }
@@ -244,7 +245,7 @@ impl ProfileManager {
         let profile = Profile {
             profile: ProfileMeta {
                 name: name.to_string(),
-                icon: icon.unwrap_or_else(|| "".to_string()),
+                icon: icon.unwrap_or_default(),
                 color: "#4A90D9".to_string(),
                 is_default: false,
             },
@@ -270,11 +271,13 @@ impl ProfileManager {
             return Err(CswError::ProfileAlreadyExists("default".to_string()));
         }
         if source_name == target_name {
-            return Err(CswError::Other("Source and target profile names must be different".to_string()));
+            return Err(CswError::Other(
+                "Source and target profile names must be different".to_string(),
+            ));
         }
 
         let source_profile = self.get_profile(source_name)?;
-        
+
         let profiles_dir = self.app_config.lock().unwrap().profiles_dir.clone();
         let target_dir = profiles_dir.join(target_name);
         let target_toml = target_dir.join("profile.toml");
@@ -316,11 +319,18 @@ impl ProfileManager {
                 let entry = entry?;
                 let path = entry.path();
                 let filename = entry.file_name();
-                let target_path = target_profile.isolation.desktop_user_data_dir.join(&filename);
+                let target_path = target_profile
+                    .isolation
+                    .desktop_user_data_dir
+                    .join(&filename);
 
                 // Skip files managed by linker (will link/copy them via apply_link in linker)
                 let name_str = filename.to_string_lossy();
-                if name_str == "claude_desktop_config.json" || name_str == "git-worktrees.json" || name_str == "ant-did" || name_str == "config.json" {
+                if name_str == "claude_desktop_config.json"
+                    || name_str == "git-worktrees.json"
+                    || name_str == "ant-did"
+                    || name_str == "config.json"
+                {
                     continue;
                 }
 
@@ -343,8 +353,14 @@ impl ProfileManager {
                 let target_path = target_profile.isolation.cli_config_dir.join(&filename);
 
                 let name_str = filename.to_string_lossy();
-                if name_str == "settings.json" || name_str == "CLAUDE.md" || name_str == "projects" || name_str == "plugins" 
-                   || name_str == "skills" || name_str == "sessions" || name_str == "history.jsonl" {
+                if name_str == "settings.json"
+                    || name_str == "CLAUDE.md"
+                    || name_str == "projects"
+                    || name_str == "plugins"
+                    || name_str == "skills"
+                    || name_str == "sessions"
+                    || name_str == "history.jsonl"
+                {
                     continue;
                 }
 
@@ -393,7 +409,7 @@ impl ProfileManager {
 
         let profile = self.get_profile(name)?;
         let linker = linker::Linker::new(self.provider.as_ref());
-        
+
         // Clean up symlinks first
         linker.unlink_profile(&profile)?;
 
@@ -430,4 +446,3 @@ impl ProfileManager {
 
 #[cfg(test)]
 mod tests;
-

--- a/crates/core/src/profile/tests.rs
+++ b/crates/core/src/profile/tests.rs
@@ -1,7 +1,7 @@
+use super::*;
+use crate::platform::mock::MockPlatformProvider;
 use std::sync::Arc;
 use tempfile::tempdir;
-use crate::platform::mock::MockPlatformProvider;
-use super::*;
 
 fn setup_test_manager() -> (Arc<MockPlatformProvider>, ProfileManager, tempfile::TempDir) {
     let tmp_dir = tempdir().unwrap();
@@ -27,24 +27,27 @@ fn setup_test_manager() -> (Arc<MockPlatformProvider>, ProfileManager, tempfile:
 #[test]
 fn test_default_profile() {
     let (_, manager, _tmp_dir) = setup_test_manager();
-    
-    let default_profile = manager.get_profile("default").expect("Failed to get default profile");
+
+    let default_profile = manager
+        .get_profile("default")
+        .expect("Failed to get default profile");
     assert_eq!(default_profile.profile.name, "default");
     assert!(default_profile.profile.is_default);
-    
+
     assert_eq!(manager.active_profile_name(), "default");
 }
 
 #[test]
 fn test_create_profile() {
     let (_, manager, _tmp_dir) = setup_test_manager();
-    
-    let profile = manager.create_profile("test_profile", SharingConfig::default(), None)
+
+    let profile = manager
+        .create_profile("test_profile", SharingConfig::default(), None)
         .expect("Failed to create profile");
-        
+
     assert_eq!(profile.profile.name, "test_profile");
-    assert_eq!(profile.profile.is_default, false);
-    
+    assert!(!profile.profile.is_default);
+
     // Verify it shows up in list
     let list = manager.list_profiles().unwrap();
     assert!(list.contains(&"test_profile".to_string()));
@@ -54,15 +57,18 @@ fn test_create_profile() {
 #[test]
 fn test_delete_profile() {
     let (_, manager, _tmp_dir) = setup_test_manager();
-    
-    manager.create_profile("to_delete", SharingConfig::default(), None)
+
+    manager
+        .create_profile("to_delete", SharingConfig::default(), None)
         .expect("Failed to create profile");
-        
+
     let list = manager.list_profiles().unwrap();
     assert!(list.contains(&"to_delete".to_string()));
-    
-    manager.delete_profile("to_delete").expect("Failed to delete profile");
-    
+
+    manager
+        .delete_profile("to_delete")
+        .expect("Failed to delete profile");
+
     let list_after = manager.list_profiles().unwrap();
     assert!(!list_after.contains(&"to_delete".to_string()));
 }
@@ -70,15 +76,17 @@ fn test_delete_profile() {
 #[test]
 fn test_delete_default_or_active_fails() {
     let (_, manager, _tmp_dir) = setup_test_manager();
-    
+
     // Deleting default fails
     let res = manager.delete_profile("default");
     assert!(res.is_err());
-    
+
     // Deleting active fails
-    manager.create_profile("active_prof", SharingConfig::default(), None).unwrap();
+    manager
+        .create_profile("active_prof", SharingConfig::default(), None)
+        .unwrap();
     manager.switch_to("active_prof").unwrap();
-    
+
     let res2 = manager.delete_profile("active_prof");
     assert!(res2.is_err());
 }
@@ -86,23 +94,24 @@ fn test_delete_default_or_active_fails() {
 #[test]
 fn test_clone_profile() {
     let (_, manager, _tmp_dir) = setup_test_manager();
-    
+
     // Create an original profile to clone from
-    let original = manager.create_profile("original", SharingConfig::default(), None)
+    let original = manager
+        .create_profile("original", SharingConfig::default(), None)
         .expect("Failed to create original profile");
 
     // Clone it
-    let cloned = manager.clone_profile("original", "cloned")
+    let cloned = manager
+        .clone_profile("original", "cloned")
         .expect("Failed to clone profile");
 
     assert_eq!(cloned.profile.name, "cloned");
     assert_eq!(cloned.profile.icon, original.profile.icon);
     assert_eq!(cloned.profile.color, original.profile.color);
-    assert_eq!(cloned.profile.is_default, false);
+    assert!(!cloned.profile.is_default);
 
     // Verify it exists in profiles list
     let list = manager.list_profiles().unwrap();
     assert!(list.contains(&"original".to_string()));
     assert!(list.contains(&"cloned".to_string()));
 }
-

--- a/crates/core/src/switcher/desktop.rs
+++ b/crates/core/src/switcher/desktop.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
-use crate::profile::Profile;
 use crate::platform::PlatformProvider;
+use crate::profile::Profile;
 
 /// Launch Claude Desktop for the given profile using --user-data-dir
 pub fn launch_desktop(profile: &Profile, provider: &dyn PlatformProvider) -> Result<()> {

--- a/crates/core/src/switcher/mod.rs
+++ b/crates/core/src/switcher/mod.rs
@@ -27,10 +27,7 @@ pub struct ContextSwitcher {
 }
 
 impl ContextSwitcher {
-    pub fn new(
-        provider: Arc<dyn PlatformProvider>,
-        profile_manager: Arc<ProfileManager>,
-    ) -> Self {
+    pub fn new(provider: Arc<dyn PlatformProvider>, profile_manager: Arc<ProfileManager>) -> Self {
         Self {
             _provider: provider,
             profile_manager,

--- a/crates/core/src/watcher/mod.rs
+++ b/crates/core/src/watcher/mod.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
-use std::sync::Arc;
-use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
 use crate::error::Result;
 use crate::profile::{ProfileManager, SharingMode};
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::Path;
+use std::sync::Arc;
 
 pub struct FileWatcher {
     profile_manager: Arc<ProfileManager>,
@@ -50,15 +50,16 @@ impl FileWatcher {
 
         let (tx, rx) = std::sync::mpsc::channel();
 
-        let mut watcher = notify::recommended_watcher(move |res: std::result::Result<Event, notify::Error>| {
-            if let Ok(event) = res {
-                if event.kind.is_modify() {
+        let mut watcher =
+            notify::recommended_watcher(move |res: std::result::Result<Event, notify::Error>| {
+                if let Ok(event) = res
+                    && event.kind.is_modify()
+                {
                     for path in event.paths {
                         let _ = tx.send(path);
                     }
                 }
-            }
-        })?;
+            })?;
 
         for path in &paths_to_watch {
             if path.exists() {
@@ -78,7 +79,11 @@ impl FileWatcher {
         Ok(())
     }
 
-    fn sync_file(modified_path: &Path, active_name: &str, profile_manager: &ProfileManager) -> Result<()> {
+    fn sync_file(
+        modified_path: &Path,
+        active_name: &str,
+        profile_manager: &ProfileManager,
+    ) -> Result<()> {
         let file_name = match modified_path.file_name().and_then(|n| n.to_str()) {
             Some(name) => name,
             None => return Ok(()),
@@ -90,7 +95,7 @@ impl FileWatcher {
                 continue;
             }
 
-            let other_profile = profile_manager.get_profile(&p_name)?;
+            let other_profile = profile_manager.get_profile(p_name)?;
             // Check if this other profile shares the same source and has this component as Copy
             let is_match = match file_name {
                 "settings.json" => {
@@ -117,9 +122,10 @@ impl FileWatcher {
                     "settings.json" | "CLAUDE.md" => {
                         other_profile.isolation.cli_config_dir.join(file_name)
                     }
-                    "claude_desktop_config.json" | "git-worktrees.json" => {
-                        other_profile.isolation.desktop_user_data_dir.join(file_name)
-                    }
+                    "claude_desktop_config.json" | "git-worktrees.json" => other_profile
+                        .isolation
+                        .desktop_user_data_dir
+                        .join(file_name),
                     _ => continue,
                 };
 

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -1,5 +1,5 @@
-use csw_core::platform::mock::MockPlatformProvider;
 use csw_core::platform::PlatformProvider;
+use csw_core::platform::mock::MockPlatformProvider;
 use csw_core::profile::{ProfileManager, SharingConfig, SharingMode, SharingSource};
 use csw_core::switcher::ContextSwitcher;
 use std::fs;
@@ -16,7 +16,8 @@ fn setup_dummy_claude_data(desktop_path: &Path, cli_path: &Path) {
     fs::write(
         &config_path,
         "{\"mcpServers\":{\"dummy\":{\"command\":\"dummy-cmd\"}},\"theme\":\"dark\"}",
-    ).unwrap();
+    )
+    .unwrap();
 
     let app_config_path = desktop_path.join("config.json");
     fs::write(&app_config_path, "{\"device_id\":\"dummy-device-id-1234\"}").unwrap();
@@ -37,27 +38,34 @@ fn setup_dummy_claude_data(desktop_path: &Path, cli_path: &Path) {
 
     let plugins_path = cli_path.join("plugins");
     fs::create_dir_all(&plugins_path).unwrap();
-    fs::write(plugins_path.join("dummy_plugin.js"), "console.log('dummy');").unwrap();
+    fs::write(
+        plugins_path.join("dummy_plugin.js"),
+        "console.log('dummy');",
+    )
+    .unwrap();
 
     let skills_path = cli_path.join("skills");
     fs::create_dir_all(&skills_path).unwrap();
     fs::write(
         skills_path.join("git_helper.json"),
         "{\"name\":\"git master assistant\",\"description\":\"helper for git commands\"}",
-    ).unwrap();
+    )
+    .unwrap();
 
     let sessions_path = cli_path.join("sessions");
     fs::create_dir_all(&sessions_path).unwrap();
     fs::write(
         sessions_path.join("session_99.json"),
         "{\"session_id\":\"99\",\"chat_history\":[]}",
-    ).unwrap();
+    )
+    .unwrap();
 
     let history_path = cli_path.join("history.jsonl");
     fs::write(
         &history_path,
         "{\"timestamp\":\"2026-06-27T00:00:00Z\",\"command\":\"claude test\"}\n",
-    ).unwrap();
+    )
+    .unwrap();
 }
 
 // Account/session isolation is achieved purely via per-profile directories
@@ -119,21 +127,23 @@ fn test_profile_sharing_and_isolation_matrix() {
 
     // Configure a matrix of Share, Copy, and Isolate components
     let matrix_sharing = SharingConfig {
-        desktop_config: SharingMode::Share,       // MCP server config -> Shared (symlink)
-        desktop_app_config: SharingMode::Copy,    // App preferences -> Copied
-        cli_settings: SharingMode::Isolate,       // CLI settings -> Isolated (none initially)
-        cli_claude_md: SharingMode::Share,        // CLAUDE.md -> Shared (symlink)
-        cli_project_memory: SharingMode::Share,   // Project memory -> Shared (symlink)
-        cli_plugins: SharingMode::Isolate,        // Plugins -> Isolated (empty dir)
-        cli_skills: SharingMode::Copy,            // Skills -> Copied (physical copy)
-        cli_sessions: SharingMode::Isolate,       // Sessions -> Isolated (empty dir)
-        cli_history: SharingMode::Isolate,        // History -> Isolated (none)
-        desktop_worktrees: SharingMode::Copy,     // Worktrees -> Copied
-        desktop_device_id: SharingMode::Share,     // Device ID -> Shared
+        desktop_config: SharingMode::Share, // MCP server config -> Shared (symlink)
+        desktop_app_config: SharingMode::Copy, // App preferences -> Copied
+        cli_settings: SharingMode::Isolate, // CLI settings -> Isolated (none initially)
+        cli_claude_md: SharingMode::Share,  // CLAUDE.md -> Shared (symlink)
+        cli_project_memory: SharingMode::Share, // Project memory -> Shared (symlink)
+        cli_plugins: SharingMode::Isolate,  // Plugins -> Isolated (empty dir)
+        cli_skills: SharingMode::Copy,      // Skills -> Copied (physical copy)
+        cli_sessions: SharingMode::Isolate, // Sessions -> Isolated (empty dir)
+        cli_history: SharingMode::Isolate,  // History -> Isolated (none)
+        desktop_worktrees: SharingMode::Copy, // Worktrees -> Copied
+        desktop_device_id: SharingMode::Share, // Device ID -> Shared
         source: SharingSource::default(),
     };
 
-    let profile = profile_manager.create_profile("CustomMatrix", matrix_sharing, None).unwrap();
+    let profile = profile_manager
+        .create_profile("CustomMatrix", matrix_sharing, None)
+        .unwrap();
     let target_desktop = &profile.isolation.desktop_user_data_dir;
     let target_cli = &profile.isolation.cli_config_dir;
 
@@ -159,7 +169,11 @@ fn test_profile_sharing_and_isolation_matrix() {
     assert!(!platform.is_symlink(&target_skills_dir));
     let target_skill_file = target_skills_dir.join("git_helper.json");
     assert!(target_skill_file.exists());
-    assert!(fs::read_to_string(target_skill_file).unwrap().contains("git master assistant"));
+    assert!(
+        fs::read_to_string(target_skill_file)
+            .unwrap()
+            .contains("git master assistant")
+    );
 
     // --- ASSERTIONS FOR ISOLATE MODE ---
     let target_settings = target_cli.join("settings.json");
@@ -196,9 +210,11 @@ fn test_profile_cloning_with_data() {
     let profile_manager = Arc::new(ProfileManager::new(platform.clone()).unwrap());
 
     // Create OriginalWork that copies skills from the default environment.
-    let mut sharing = SharingConfig::default();
-    sharing.cli_skills = SharingMode::Copy;
-    sharing.cli_sessions = SharingMode::Isolate;
+    let sharing = SharingConfig {
+        cli_skills: SharingMode::Copy,
+        cli_sessions: SharingMode::Isolate,
+        ..Default::default()
+    };
     profile_manager
         .create_profile("OriginalWork", sharing, None)
         .unwrap();

--- a/crates/desktop/src/main.rs
+++ b/crates/desktop/src/main.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 use tauri::{
+    AppHandle, Manager, State, Wry,
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::TrayIconBuilder,
-    AppHandle, Manager, State, Wry,
 };
 
 use csw_core::platform::create_provider;
@@ -26,7 +26,10 @@ async fn get_active_profile(state: State<'_, AppState>) -> Result<String, String
 
 #[tauri::command]
 async fn list_profiles(state: State<'_, AppState>) -> Result<Vec<serde_json::Value>, String> {
-    let names = state.profile_manager.list_profiles().map_err(|e| e.to_string())?;
+    let names = state
+        .profile_manager
+        .list_profiles()
+        .map_err(|e| e.to_string())?;
     let mut list = Vec::new();
     for name in names {
         if let Ok(p) = state.profile_manager.get_profile(&name) {
@@ -41,9 +44,15 @@ async fn list_profiles(state: State<'_, AppState>) -> Result<Vec<serde_json::Val
 }
 
 #[tauri::command]
-async fn get_profile_details(name: String, state: State<'_, AppState>) -> Result<serde_json::Value, String> {
-    let p = state.profile_manager.get_profile(&name).map_err(|e| e.to_string())?;
-    
+async fn get_profile_details(
+    name: String,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let p = state
+        .profile_manager
+        .get_profile(&name)
+        .map_err(|e| e.to_string())?;
+
     // Convert to JSON representation for frontend
     let val = serde_json::json!({
         "name": p.profile.name,
@@ -66,7 +75,7 @@ async fn get_profile_details(name: String, state: State<'_, AppState>) -> Result
             "desktop_device_id": format!("{:?}", p.sharing.desktop_device_id).to_lowercase()
         }
     });
-    
+
     Ok(val)
 }
 
@@ -87,17 +96,27 @@ async fn create_profile(
         sharing.desktop_worktrees = SharingMode::Share;
     }
 
-    state.profile_manager.create_profile(&name, sharing, icon).map_err(|e| e.to_string())?;
-    
+    state
+        .profile_manager
+        .create_profile(&name, sharing, icon)
+        .map_err(|e| e.to_string())?;
+
     // Update system tray menu after change
     update_tray_menu(&app)?;
-    
+
     Ok(())
 }
 
 #[tauri::command]
-async fn delete_profile(name: String, state: State<'_, AppState>, app: AppHandle) -> Result<(), String> {
-    state.profile_manager.delete_profile(&name).map_err(|e| e.to_string())?;
+async fn delete_profile(
+    name: String,
+    state: State<'_, AppState>,
+    app: AppHandle,
+) -> Result<(), String> {
+    state
+        .profile_manager
+        .delete_profile(&name)
+        .map_err(|e| e.to_string())?;
     update_tray_menu(&app)?;
     Ok(())
 }
@@ -109,7 +128,10 @@ async fn clone_profile(
     state: State<'_, AppState>,
     app: AppHandle,
 ) -> Result<(), String> {
-    state.profile_manager.clone_profile(&source, &target).map_err(|e| e.to_string())?;
+    state
+        .profile_manager
+        .clone_profile(&source, &target)
+        .map_err(|e| e.to_string())?;
     update_tray_menu(&app)?;
     Ok(())
 }
@@ -123,12 +145,15 @@ async fn switch_profile(
 ) -> Result<(), String> {
     let switcher = ContextSwitcher::new(state.provider.clone(), state.profile_manager.clone());
     switcher.switch_to(&name).map_err(|e| e.to_string())?;
-    
+
     // Update system tray menu
     update_tray_menu(&app)?;
 
     if !no_launch && name != "default" {
-        let profile = state.profile_manager.get_profile(&name).map_err(|e| e.to_string())?;
+        let profile = state
+            .profile_manager
+            .get_profile(&name)
+            .map_err(|e| e.to_string())?;
         let _ = csw_core::switcher::desktop::launch_desktop(&profile, state.provider.as_ref());
     }
 
@@ -137,21 +162,34 @@ async fn switch_profile(
 
 #[tauri::command]
 async fn get_desktop_running_status(state: State<'_, AppState>) -> Result<bool, String> {
-    state.provider.is_claude_desktop_running().map_err(|e| e.to_string())
+    state
+        .provider
+        .is_claude_desktop_running()
+        .map_err(|e| e.to_string())
 }
 
 // Function to update the system tray menu dynamically
 fn update_tray_menu(app: &AppHandle) -> Result<(), String> {
     let state = app.state::<AppState>();
-    let profiles = state.profile_manager.list_profiles().map_err(|e| e.to_string())?;
+    let profiles = state
+        .profile_manager
+        .list_profiles()
+        .map_err(|e| e.to_string())?;
     let active_name = state.profile_manager.active_profile_name();
 
     let mut menu_items = Vec::new();
-    
+
     // 1. Title Item
-    let title_item = MenuItem::with_id(app, "title", "🔵 Claude Desktop Switcher", false, None::<&str>).map_err(|e| e.to_string())?;
+    let title_item = MenuItem::with_id(
+        app,
+        "title",
+        "🔵 Claude Desktop Switcher",
+        false,
+        None::<&str>,
+    )
+    .map_err(|e| e.to_string())?;
     menu_items.push(Box::new(title_item) as Box<dyn tauri::menu::IsMenuItem<Wry>>);
-    
+
     let sep1 = PredefinedMenuItem::separator(app).map_err(|e| e.to_string())?;
     menu_items.push(Box::new(sep1) as Box<dyn tauri::menu::IsMenuItem<Wry>>);
 
@@ -162,15 +200,16 @@ fn update_tray_menu(app: &AppHandle) -> Result<(), String> {
         } else {
             format!("○ {}", p_name)
         };
-        
+
         let p_item = MenuItem::with_id(
             app,
             format!("profile_{}", p_name),
             label,
             true,
-            None::<&str>
-        ).map_err(|e| e.to_string())?;
-        
+            None::<&str>,
+        )
+        .map_err(|e| e.to_string())?;
+
         menu_items.push(Box::new(p_item) as Box<dyn tauri::menu::IsMenuItem<Wry>>);
     }
 
@@ -178,14 +217,23 @@ fn update_tray_menu(app: &AppHandle) -> Result<(), String> {
     let sep2 = PredefinedMenuItem::separator(app).map_err(|e| e.to_string())?;
     menu_items.push(Box::new(sep2) as Box<dyn tauri::menu::IsMenuItem<Wry>>);
 
-    let settings_item = MenuItem::with_id(app, "settings", "⚙ 設定...", true, None::<&str>).map_err(|e| e.to_string())?;
+    let settings_item = MenuItem::with_id(app, "settings", "⚙ 設定...", true, None::<&str>)
+        .map_err(|e| e.to_string())?;
     menu_items.push(Box::new(settings_item) as Box<dyn tauri::menu::IsMenuItem<Wry>>);
 
-    let quit_item = MenuItem::with_id(app, "quit", "終了", true, None::<&str>).map_err(|e| e.to_string())?;
+    let quit_item =
+        MenuItem::with_id(app, "quit", "終了", true, None::<&str>).map_err(|e| e.to_string())?;
     menu_items.push(Box::new(quit_item) as Box<dyn tauri::menu::IsMenuItem<Wry>>);
 
     // Reconstruct the menu
-    let menu = Menu::with_items(app, &menu_items.iter().map(|item| item.as_ref()).collect::<Vec<_>>()).map_err(|e| e.to_string())?;
+    let menu = Menu::with_items(
+        app,
+        &menu_items
+            .iter()
+            .map(|item| item.as_ref())
+            .collect::<Vec<_>>(),
+    )
+    .map_err(|e| e.to_string())?;
 
     if let Some(tray) = app.tray_by_id("main_tray") {
         tray.set_menu(Some(menu)).map_err(|e| e.to_string())?;
@@ -195,8 +243,11 @@ fn update_tray_menu(app: &AppHandle) -> Result<(), String> {
 }
 
 fn main() {
-    let provider: Arc<dyn csw_core::platform::PlatformProvider> = Arc::from(create_provider().expect("Failed to initialize platform provider"));
-    let profile_manager = Arc::new(ProfileManager::new(provider.clone()).expect("Failed to initialize profile manager"));
+    let provider: Arc<dyn csw_core::platform::PlatformProvider> =
+        Arc::from(create_provider().expect("Failed to initialize platform provider"));
+    let profile_manager = Arc::new(
+        ProfileManager::new(provider.clone()).expect("Failed to initialize profile manager"),
+    );
 
     let app_state = AppState {
         provider,
@@ -222,20 +273,25 @@ fn main() {
                             let _ = window.show();
                             let _ = window.set_focus();
                         }
-                    } else if id.starts_with("profile_") {
-                        let profile_name = &id[8..];
+                    } else if let Some(profile_name) = id.strip_prefix("profile_") {
                         let state = app.state::<AppState>();
-                        let switcher = ContextSwitcher::new(state.provider.clone(), state.profile_manager.clone());
-                        
+                        let switcher = ContextSwitcher::new(
+                            state.provider.clone(),
+                            state.profile_manager.clone(),
+                        );
+
                         if let Err(e) = switcher.switch_to(profile_name) {
                             eprintln!("Failed to switch profile: {}", e);
                         } else {
                             let _ = update_tray_menu(app);
                             // Auto-launch if switched (except to default)
-                            if profile_name != "default" {
-                                if let Ok(profile) = state.profile_manager.get_profile(profile_name) {
-                                    let _ = csw_core::switcher::desktop::launch_desktop(&profile, state.provider.as_ref());
-                                }
+                            if profile_name != "default"
+                                && let Ok(profile) = state.profile_manager.get_profile(profile_name)
+                            {
+                                let _ = csw_core::switcher::desktop::launch_desktop(
+                                    &profile,
+                                    state.provider.as_ref(),
+                                );
                             }
                         }
                     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# Pin the Rust toolchain so local, CI, and release builds all use the same
+# compiler and lint set (matches the committed Cargo.lock philosophy). Bump
+# this deliberately when adopting a newer toolchain.
+[toolchain]
+channel = "1.96.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
## 概要

clippy / rustfmt を CI で強制し、origin/main が抱えていた lint / format 債務を解消する。引き継ぎ後に発見した「doc と実態の乖離」への対応。

## 動機

既存 CI(build.yml / test.yml / security.yml)は **clippy も fmt も実行していない**のに、`core_commit_standard` skill は「CI(`cargo fmt` / `cargo clippy` / `cargo test`)が全てパスしてからマージ」と明記しており、宣言と実態が食い違っていた。ローカル(1.96.0)検証では origin/main は `clippy -D warnings` で 6 件、`fmt --check` で多数の差分を抱えていた。

## 変更

- **`rust-toolchain.toml`**: ツールチェーンを 1.96.0 に固定し clippy / rustfmt コンポーネントを宣言。ローカル・CI・リリースで同一の compiler / lint を使う(`Cargo.lock` 固定と同じ再現性の思想)。
- **`.github/workflows/lint.yml`**: `cargo fmt --all -- --check` と `cargo clippy --workspace --all-targets -- -D warnings` を macos-latest で実行。
- **clippy 指摘の解消**: `MacOsProvider` の `Default` 実装、`collapsible_if` の let-chain 化(config.rs / watcher)、`SharingMode` の `derive(Default)`、`unwrap_or_default`、`needless_borrow`、`field_reassign_with_default`。いずれも semantics-preserving。
- **`cargo fmt --all`** で全体を整形(差分の大半はこの整形)。
- **dead な `platform::windows` 足場を撤去**: 実体ファイル `windows.rs` が無く Windows ビルドは元々コンパイル不能だった。rustfmt は cfg を評価せず `mod windows;` の解決に失敗するため、macOS 専用アプリとして撤去し、非 macOS は `create_provider` が `UnsupportedPlatform` を返すよう整理。

## 検証(ローカル 1.96.0)

- `cargo fmt --all -- --check`: PASS
- `cargo clippy --workspace --all-targets -- -D warnings`: PASS
- `cargo test --workspace --exclude csw-desktop`: PASS、`cargo build -p csw-desktop`: PASS

## 補足

- マージ後、branch protection の必須チェックに本ワークフロー(`Clippy and rustfmt`)を追加すると恒久的に強制できる(別途設定)。
