### PR TITLE
ci: macOS CI のコストを削減(concurrency / cache / トリガ削減 / dep group)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,23 @@
 version: 2
 updates:
-  # Keep GitHub Actions SHA pins fresh (security: avoid stale third-party actions)
+  # Keep GitHub Actions SHA pins fresh (security: avoid stale third-party actions).
+  # Group all action bumps into a single weekly PR to minimize CI runs.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
-  # Keep Rust dependencies updated
+  # Keep Rust dependencies updated. Group all cargo bumps into a single weekly
+  # PR (one CI run instead of one per crate).
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      cargo:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,13 @@
 name: Build
 
+# Heavy macOS job: run on PRs only (post-merge re-runs are redundant with
+# branch protection's PR checks) and cancel superseded runs to save minutes.
 on:
-  push:
-    branches:
-      - main
   pull_request:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -15,6 +18,9 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build all crates
         run: cargo build --workspace

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,12 @@
 name: Lint
 
+# Heavy macOS job: run on PRs only and cancel superseded runs to save minutes.
 on:
-  push:
-    branches:
-      - main
   pull_request:
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -15,6 +17,12 @@ jobs:
 
       # The toolchain version and the clippy/rustfmt components are pinned by
       # rust-toolchain.toml, which rustup auto-installs on first cargo use.
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           targets: aarch64-apple-darwin, x86_64-apple-darwin
 
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # action-v0.6.2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     name: Secret scan (gitleaks)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,12 @@
 name: Test
 
+# Heavy macOS job: run on PRs only and cancel superseded runs to save minutes.
 on:
-  push:
-    branches:
-      - main
   pull_request:
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -16,6 +18,8 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Run unit and integration tests
         run: cargo test --workspace --exclude csw-desktop


### PR DESCRIPTION
## 概要

macOS CI(Build/Test/Lint、分単価10倍)の実行回数と1回あたりの分数を削減し、GitHub Actions の課金消費を抑える。

## 動機

今セッションで Actions の spending limit に到達し CI が起動しなくなった(「The job was not started because ... spending limit needs to be increased」)。主因:
- strict=true(up-to-date必須)による rebase 毎の macOS CI 再実行(※ strict は既に解除済み)
- push:main + pull_request の重複実行
- キャッシュ無しの毎回フルビルド(macOS は分単価10倍)

## 変更

- **concurrency(cancel-in-progress)** を build/test/lint/security に追加 — 後続 push で進行中の旧 run をキャンセル
- **Swatinem/rust-cache@v2.9.1(SHA pin)** を build/test/lint/build-mac-dmg に追加 — cargo registry/target をキャッシュしフルビルドを回避
- **Build/Test/Lint のトリガを pull_request のみ**に変更(push:main の重複実行を廃止)。必須チェックは PR 上で評価されるため branch protection に影響なし
- **dependabot grouping** — action系/cargo系を各1 PR に集約(PR数=CI数を削減)
- security(gitleaks, ubuntu)は安価なため push:main を維持、concurrency のみ追加
- release.yml には concurrency を付けない(進行中の署名/公証 DMG ビルドを後続 push で cancel しないため)

## レビュー観点

- push:main を build/test/lint から外したため「マージ後の main 再検証」は行われなくなる(PR で検証済み + strict 解除済みのため許容)。main 再検証を残したい場合はトリガ変更だけ revert 可能。
- リリース DMG ビルド(build-mac-dmg)は従来どおり release_created 時のみ起動。

## マージ方針

ワークフロー変更は影響範囲が大きいので、**課金回復後に CI 検証つきで通常マージ推奨**(admin での未検証マージはしない)。YAML 構文はローカルで検証済み(python yaml + 必須チェックのジョブ名は不変)。
