### PR TITLE
fix(core): プロファイル操作を堅牢化(apply_link 原子化 + 切替前プロセス検知)

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -31,6 +31,11 @@ pub enum CswError {
     #[error("Refused to delete '{0}': path lies inside the real Claude default data directory")]
     RefusedDefaultDataDeletion(String),
 
+    #[error(
+        "Claude Desktop is running. Quit it before switching profiles to avoid cache write-back and data races."
+    )]
+    DesktopRunning,
+
     #[error("Platform not supported: {0}")]
     UnsupportedPlatform(String),
 

--- a/crates/core/src/platform/mock.rs
+++ b/crates/core/src/platform/mock.rs
@@ -1,11 +1,16 @@
-use crate::error::Result;
+use crate::error::{CswError, Result};
 use crate::platform::PlatformProvider;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 pub struct MockPlatformProvider {
     pub desktop_default: PathBuf,
     pub cli_default: PathBuf,
     pub app_data: PathBuf,
+    /// Test knob: report Claude Desktop as running.
+    desktop_running: AtomicBool,
+    /// Test knob: make `create_symlink` fail (to exercise rollback paths).
+    fail_symlink: AtomicBool,
 }
 
 impl MockPlatformProvider {
@@ -14,7 +19,21 @@ impl MockPlatformProvider {
             desktop_default,
             cli_default,
             app_data,
+            desktop_running: AtomicBool::new(false),
+            fail_symlink: AtomicBool::new(false),
         }
+    }
+
+    /// Builder: make `is_claude_desktop_running` report `running`.
+    pub fn with_desktop_running(self, running: bool) -> Self {
+        self.desktop_running.store(running, Ordering::SeqCst);
+        self
+    }
+
+    /// Builder: make `create_symlink` fail, to test rollback/atomicity paths.
+    pub fn with_symlink_failure(self, fail: bool) -> Self {
+        self.fail_symlink.store(fail, Ordering::SeqCst);
+        self
     }
 }
 
@@ -40,6 +59,9 @@ impl PlatformProvider for MockPlatformProvider {
         target_path: &std::path::Path,
         link_path: &std::path::Path,
     ) -> Result<()> {
+        if self.fail_symlink.load(Ordering::SeqCst) {
+            return Err(CswError::Other("mock: create_symlink failed".to_string()));
+        }
         #[cfg(unix)]
         std::os::unix::fs::symlink(target_path, link_path)?;
         #[cfg(windows)]
@@ -67,7 +89,7 @@ impl PlatformProvider for MockPlatformProvider {
     }
 
     fn is_claude_desktop_running(&self) -> Result<bool> {
-        Ok(false)
+        Ok(self.desktop_running.load(Ordering::SeqCst))
     }
 
     fn claude_desktop_pids(&self) -> Result<Vec<u32>> {

--- a/crates/core/src/profile/linker.rs
+++ b/crates/core/src/profile/linker.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::{CswError, Result};
 use crate::platform::PlatformProvider;
@@ -184,37 +184,28 @@ impl<'a> Linker<'a> {
         mode: SharingMode,
         is_directory: bool,
     ) -> Result<()> {
-        // Clear target if it exists and is a symlink (avoid duplicates/errors)
+        // A pre-existing symlink points elsewhere, so removing it never loses
+        // real data; clear it before re-applying.
         if self.provider.is_symlink(target) {
             self.provider.remove_symlink(target)?;
-        } else if target.exists() {
-            // Keep existing files if they were manually created or copies,
-            // but if we are switching to Share, we must clear them.
-            if mode == SharingMode::Share {
-                self.assert_safe_to_delete(target)?;
-                if target.is_file() {
-                    fs::remove_file(target)?;
-                } else {
-                    fs::remove_dir_all(target)?;
-                }
-            } else {
-                // If target exists and mode is copy or isolate, leave it as is
-                return Ok(());
-            }
+        } else if target.exists() && mode != SharingMode::Share {
+            // For Copy/Isolate, an existing real target is left untouched.
+            return Ok(());
         }
 
-        // Apply based on mode
         match mode {
             SharingMode::Share => {
                 if source.exists() {
-                    self.provider.create_symlink(source, target)?;
-                } else {
-                    // Source doesn't exist, we don't symlink yet.
-                    // Instead, we might create the directory structure if it is a directory.
-                    if is_directory {
-                        fs::create_dir_all(target)?;
-                    }
+                    // Replace the target with a symlink without a destructive
+                    // gap: a real target is moved aside and only dropped once the
+                    // symlink exists (restored on failure).
+                    self.replace_with_symlink(source, target)?;
+                } else if is_directory && !target.exists() {
+                    // No source to share yet: just ensure the directory exists.
+                    fs::create_dir_all(target)?;
                 }
+                // Source missing but a real target exists: leave it as-is rather
+                // than destroying real data for nothing.
             }
             SharingMode::Copy => {
                 if source.exists() {
@@ -228,13 +219,60 @@ impl<'a> Linker<'a> {
             SharingMode::Isolate => {
                 if is_directory {
                     fs::create_dir_all(target)?;
-                } else {
-                    // Create an empty file or basic default config if needed,
-                    // but for most, leaving it empty/absent is correct.
                 }
             }
         }
 
+        Ok(())
+    }
+
+    /// Replace `target` with a symlink to `source`. If `target` is an existing
+    /// real (non-symlink) file or directory, move it aside first and only delete
+    /// the backup once the symlink is created — restoring it on failure — so a
+    /// crash mid-operation never loses the data.
+    fn replace_with_symlink(&self, source: &Path, target: &Path) -> Result<()> {
+        if !target.exists() {
+            self.provider.create_symlink(source, target)?;
+            return Ok(());
+        }
+
+        // A real target is about to be replaced; never touch the real default data.
+        self.assert_safe_to_delete(target)?;
+
+        let backup = Self::backup_path(target);
+        Self::remove_path(&backup)?; // clear any stale backup from an interrupted run
+        fs::rename(target, &backup)?;
+
+        match self.provider.create_symlink(source, target) {
+            Ok(()) => {
+                Self::remove_path(&backup)?;
+                Ok(())
+            }
+            Err(e) => {
+                // Roll back: restore the original target.
+                let _ = fs::rename(&backup, target);
+                Err(e)
+            }
+        }
+    }
+
+    /// Sibling backup path used while atomically replacing a target.
+    fn backup_path(target: &Path) -> PathBuf {
+        let mut name = target
+            .file_name()
+            .map(|n| n.to_os_string())
+            .unwrap_or_default();
+        name.push(".csw-backup");
+        target.with_file_name(name)
+    }
+
+    /// Remove a file or directory if it exists (no-op otherwise).
+    fn remove_path(path: &Path) -> Result<()> {
+        if path.is_dir() {
+            fs::remove_dir_all(path)?;
+        } else if path.symlink_metadata().is_ok() {
+            fs::remove_file(path)?;
+        }
         Ok(())
     }
 
@@ -378,5 +416,43 @@ mod tests {
 
         // After Share, the target becomes a symlink to the source.
         assert!(provider.is_symlink(&target));
+    }
+
+    /// If creating the symlink fails mid-operation, a pre-existing real target
+    /// (and its data) must be restored rather than left deleted.
+    #[test]
+    fn apply_link_share_restores_target_when_symlink_fails() {
+        let desktop_dir = tempdir().unwrap();
+        let cli_dir = tempdir().unwrap();
+        let app_dir = tempdir().unwrap();
+        let profile_dir = tempdir().unwrap();
+
+        // Real per-profile target dir (NOT under the default dirs) with data.
+        let target = profile_dir.path().join("plugins");
+        fs::create_dir_all(&target).unwrap();
+        let data = target.join("keep.js");
+        fs::write(&data, "important").unwrap();
+
+        let source_dir = tempdir().unwrap();
+        let source_plugins = source_dir.path().join("plugins");
+        fs::create_dir_all(&source_plugins).unwrap();
+
+        // Provider whose create_symlink always fails.
+        let provider = MockPlatformProvider::new(
+            desktop_dir.path().to_path_buf(),
+            cli_dir.path().to_path_buf(),
+            app_dir.path().to_path_buf(),
+        )
+        .with_symlink_failure(true);
+
+        let linker = Linker::new(&provider);
+        let result = linker.apply_link(&source_plugins, &target, SharingMode::Share, true);
+
+        assert!(result.is_err(), "a failed symlink must surface an error");
+        assert!(target.exists(), "the original target must be restored");
+        assert!(data.exists(), "the original data must be preserved");
+        assert_eq!(fs::read_to_string(&data).unwrap(), "important");
+        let backup = target.with_file_name("plugins.csw-backup");
+        assert!(!backup.exists(), "no backup should be left behind");
     }
 }

--- a/crates/core/src/switcher/mod.rs
+++ b/crates/core/src/switcher/mod.rs
@@ -3,7 +3,7 @@ pub mod shell;
 
 use std::sync::Arc;
 
-use crate::error::Result;
+use crate::error::{CswError, Result};
 use crate::platform::PlatformProvider;
 use crate::profile::ProfileManager;
 
@@ -22,14 +22,14 @@ use crate::profile::ProfileManager;
 /// Keychain into files would only weaken security without being necessary, so
 /// that mechanism has been removed.
 pub struct ContextSwitcher {
-    _provider: Arc<dyn PlatformProvider>,
+    provider: Arc<dyn PlatformProvider>,
     profile_manager: Arc<ProfileManager>,
 }
 
 impl ContextSwitcher {
     pub fn new(provider: Arc<dyn PlatformProvider>, profile_manager: Arc<ProfileManager>) -> Self {
         Self {
-            _provider: provider,
+            provider,
             profile_manager,
         }
     }
@@ -40,10 +40,77 @@ impl ContextSwitcher {
     /// (`--user-data-dir` / `CLAUDE_CONFIG_DIR`), so this only validates the
     /// target exists and records it as the active profile. No Keychain or
     /// credential files are touched.
+    ///
+    /// Switching is refused while Claude Desktop is running: a live instance can
+    /// write cached state back into the currently active profile's directory and
+    /// race with shared (symlinked) files during the switch, so the user must
+    /// quit Claude Desktop first.
     pub fn switch_to(&self, profile_name: &str) -> Result<()> {
         // Validate the profile exists before recording it as active.
         let _ = self.profile_manager.get_profile(profile_name)?;
+
+        // Refuse to switch while Claude Desktop is running to avoid cache
+        // write-back and symlink data races.
+        if self.provider.is_claude_desktop_running()? {
+            return Err(CswError::DesktopRunning);
+        }
+
         self.profile_manager.switch_to(profile_name)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::mock::MockPlatformProvider;
+    use crate::profile::SharingConfig;
+    use tempfile::tempdir;
+
+    /// Switching while Claude Desktop is running must be refused so a live
+    /// instance cannot write cached state back / race with shared files.
+    #[test]
+    fn switch_to_refuses_while_desktop_running() {
+        let desktop_dir = tempdir().unwrap();
+        let cli_dir = tempdir().unwrap();
+        let app_dir = tempdir().unwrap();
+
+        let provider = Arc::new(
+            MockPlatformProvider::new(
+                desktop_dir.path().to_path_buf(),
+                cli_dir.path().to_path_buf(),
+                app_dir.path().to_path_buf(),
+            )
+            .with_desktop_running(true),
+        );
+        let pm = Arc::new(ProfileManager::new(provider.clone()).unwrap());
+        pm.create_profile("Work", SharingConfig::default(), None)
+            .unwrap();
+
+        let switcher = ContextSwitcher::new(provider, pm.clone());
+        let err = switcher.switch_to("Work").unwrap_err();
+        assert!(matches!(err, CswError::DesktopRunning));
+        // Active profile must be unchanged after a refused switch.
+        assert_eq!(pm.active_profile_name(), "default");
+    }
+
+    #[test]
+    fn switch_to_succeeds_when_desktop_not_running() {
+        let desktop_dir = tempdir().unwrap();
+        let cli_dir = tempdir().unwrap();
+        let app_dir = tempdir().unwrap();
+
+        let provider = Arc::new(MockPlatformProvider::new(
+            desktop_dir.path().to_path_buf(),
+            cli_dir.path().to_path_buf(),
+            app_dir.path().to_path_buf(),
+        ));
+        let pm = Arc::new(ProfileManager::new(provider.clone()).unwrap());
+        pm.create_profile("Work", SharingConfig::default(), None)
+            .unwrap();
+
+        let switcher = ContextSwitcher::new(provider, pm.clone());
+        switcher.switch_to("Work").unwrap();
+        assert_eq!(pm.active_profile_name(), "Work");
     }
 }


### PR DESCRIPTION
リンク張り替えの原子化(退避→symlink→成功時のみ破棄/失敗時復元、source 不在時は実体を消さない)と、切替前の Claude Desktop 起動中検知(CswError::DesktopRunning)を追加。実 default データは assert_safe_to_delete で継続保護。launch invocation は macOS 26.5 で open --env が正式サポートのため変更なし。テスト: RED→GREEN 3件追加(原子化復元1 + プロセス検知2)、lib 15 tests + integration 3 すべて PASS、clippy -D warnings / fmt --check PASS をローカル確認。