### PR TITLE
fix(release): universal ビルド用に x86_64 ターゲットを toolchain に追加

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,4 +4,10 @@
 [toolchain]
 channel = "1.96.0"
 components = ["clippy", "rustfmt"]
+# Both Apple targets are required for the universal-apple-darwin release build.
+# They must be declared here (not only via the release workflow's toolchain
+# action) because this file pins the toolchain used for every cargo invocation;
+# without this, the pinned 1.96.0 toolchain lacks x86_64 and the universal
+# build fails with "Target x86_64-apple-darwin is not installed".
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
 profile = "minimal"


### PR DESCRIPTION
v0.5.1 の build-mac-dmg 失敗(「Target x86_64-apple-darwin is not installed」)を修正。rust-toolchain.toml(1.96.0 固定)に aarch64/x86_64 両 Apple ターゲットを宣言し、universal ビルドが pin トールチェーンで成立するようにする。実機で両ターゲットのインストールと x86_64 クロスビルドを確認。