### PR TITLE
fix(website): LP のモバイルレイアウト崩れを修正(デスクトップ不変)

### DIFF
--- a/website/style.css
+++ b/website/style.css
@@ -712,4 +712,110 @@ html[lang="ja"] .usecases-header h2 {
     }
 }
 
+/* --- Mobile (phones / small tablets) --------------------------------------
+   Layout-only overrides scoped to small screens. Desktop (>768px) rendering
+   is intentionally left unchanged; these rules only fix overflow/oversized
+   typography and the header/hero/button arrangement on narrow viewports. */
+@media (max-width: 768px) {
+    .container {
+        padding: 0 20px;
+    }
+
+    /* Header: there is no room for in-page anchors without a menu, so drop
+       them on mobile and keep the language toggle + GitHub action. */
+    .nav-links {
+        gap: 16px;
+    }
+    .nav-links a[href^="#"] {
+        display: none;
+    }
+    .logo-text {
+        font-size: 0.95rem;
+    }
+
+    /* Hero typography scaled to phone widths */
+    .headline {
+        font-size: 2.75rem;
+        margin-bottom: 20px;
+    }
+    html[lang="ja"] .headline {
+        font-size: 2.25rem;
+    }
+    .subtext {
+        font-size: 1.1rem;
+        margin-bottom: 32px;
+    }
+    html[lang="ja"] .subtext {
+        font-size: 1.15rem;
+    }
+
+    /* Hero call-to-action buttons stack full-width instead of overflowing */
+    .button-group {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .button-group .btn {
+        width: 100%;
+    }
+
+    /* Section headings */
+    .feature-intro h2 {
+        font-size: 2.25rem;
+    }
+    html[lang="ja"] .feature-intro h2 {
+        font-size: 2rem;
+    }
+    .feature-intro p {
+        font-size: 1.15rem;
+    }
+    .usecases-header h2 {
+        font-size: 2rem;
+    }
+    html[lang="ja"] .usecases-header h2 {
+        font-size: 1.75rem;
+    }
+    .usecase-title {
+        font-size: 1.4rem;
+    }
+    .workflow-header h2,
+    .guide-header h2 {
+        font-size: 1.6rem;
+    }
+    .cell-content {
+        padding: 24px;
+    }
+    .guide-card {
+        padding: 28px;
+    }
+    .step-item {
+        gap: 20px;
+        padding: 24px 0;
+    }
+}
+
+@media (max-width: 480px) {
+    .container {
+        padding: 0 16px;
+    }
+    .headline {
+        font-size: 2.25rem;
+    }
+    html[lang="ja"] .headline {
+        font-size: 1.9rem;
+    }
+    .feature-intro h2 {
+        font-size: 1.9rem;
+    }
+    html[lang="ja"] .feature-intro h2 {
+        font-size: 1.75rem;
+    }
+    .cell-content h2 {
+        font-size: 1.4rem;
+    }
+    /* Keep the command example from forcing horizontal scroll */
+    .code-snippet code {
+        font-size: 0.78rem;
+    }
+}
+
 


### PR DESCRIPTION
スマホ幅で headline/ヘッダーnav/ヒーローのボタン列/余白が崩れていたのを、@media(≤768px/≤480px)のみ追加で修正。デスクトップ(>768px)は不変。EN/JA は共有 style.css で両対応。ヘッドレス Chrome で mobile(EN/JA)崩れ解消・desktop 不変をスクショ確認済み。