### PR TITLE
feat(desktop): 設定UIをスキル準拠で全面再設計し実データ接続・2モード化

### DIFF
--- a/crates/desktop/src/main.rs
+++ b/crates/desktop/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use tauri::{
     AppHandle, Manager, State, Wry,
@@ -79,22 +80,75 @@ async fn get_profile_details(
     Ok(val)
 }
 
+/// Parse a sharing-mode string coming from the frontend ("share" / "isolate" / "copy").
+fn parse_sharing_mode(value: &str) -> Option<SharingMode> {
+    match value {
+        "share" => Some(SharingMode::Share),
+        "isolate" => Some(SharingMode::Isolate),
+        "copy" => Some(SharingMode::Copy),
+        _ => None,
+    }
+}
+
+/// Build the per-component sharing config for a new profile from the chosen mode preset,
+/// then apply any explicit per-component overrides coming from the "advanced settings" UI.
+fn build_sharing_config(mode: &str, overrides: Option<HashMap<String, String>>) -> SharingConfig {
+    // Two-mode model surfaced in the UI:
+    //   "isolate"        — a brand-new, empty environment (= SharingConfig::default()).
+    //   "share_settings" — reuse the settings assets (MCP servers, global rules, skills,
+    //                      plugins, app config, worktrees) from the default profile via
+    //                      symlink, while keeping the account login, conversation sessions,
+    //                      command history and project memory isolated for safety.
+    // "share" is kept as a backward-compatible alias for "share_settings".
+    let mut sharing = SharingConfig::default();
+    if mode == "share_settings" || mode == "share" {
+        sharing.desktop_config = SharingMode::Share; // MCP servers
+        sharing.cli_settings = SharingMode::Share; // permissions / hooks
+        sharing.cli_claude_md = SharingMode::Share; // global rules
+        sharing.cli_plugins = SharingMode::Share;
+        sharing.cli_skills = SharingMode::Share;
+        sharing.desktop_app_config = SharingMode::Share;
+        sharing.desktop_worktrees = SharingMode::Share;
+        // cli_project_memory / cli_sessions / cli_history stay Isolate (safety side).
+        // desktop_device_id is already Share in SharingConfig::default().
+    }
+
+    // Advanced settings: explicit per-component choices override the mode preset.
+    if let Some(overrides) = overrides {
+        for (key, value) in overrides {
+            let Some(m) = parse_sharing_mode(&value) else {
+                continue;
+            };
+            match key.as_str() {
+                "desktop_config" => sharing.desktop_config = m,
+                "cli_settings" => sharing.cli_settings = m,
+                "cli_claude_md" => sharing.cli_claude_md = m,
+                "cli_project_memory" => sharing.cli_project_memory = m,
+                "cli_plugins" => sharing.cli_plugins = m,
+                "cli_skills" => sharing.cli_skills = m,
+                "cli_sessions" => sharing.cli_sessions = m,
+                "cli_history" => sharing.cli_history = m,
+                "desktop_app_config" => sharing.desktop_app_config = m,
+                "desktop_worktrees" => sharing.desktop_worktrees = m,
+                "desktop_device_id" => sharing.desktop_device_id = m,
+                _ => {}
+            }
+        }
+    }
+
+    sharing
+}
+
 #[tauri::command]
 async fn create_profile(
     name: String,
     mode: String,
     icon: Option<String>,
+    sharing_overrides: Option<HashMap<String, String>>,
     state: State<'_, AppState>,
     app: AppHandle,
 ) -> Result<(), String> {
-    let mut sharing = SharingConfig::default();
-    if mode == "share" {
-        sharing.desktop_config = SharingMode::Share;
-        sharing.cli_settings = SharingMode::Share;
-        sharing.cli_claude_md = SharingMode::Share;
-        sharing.cli_plugins = SharingMode::Share;
-        sharing.desktop_worktrees = SharingMode::Share;
-    }
+    let sharing = build_sharing_config(&mode, sharing_overrides);
 
     state
         .profile_manager
@@ -256,6 +310,14 @@ fn main() {
 
     tauri::Builder::default()
         .manage(app_state)
+        .on_window_event(|window, event| {
+            // Closing the settings window must not destroy it or quit the app:
+            // keep running in the tray/Dock and just hide, so it can be reopened.
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                api.prevent_close();
+                let _ = window.hide();
+            }
+        })
         .setup(|app| {
             // Build the system tray for the first time
             let icon = tauri::image::Image::from_bytes(include_bytes!("../icons/tray.png"))
@@ -301,6 +363,13 @@ fn main() {
             // Initial tray update
             let _ = update_tray_menu(app.handle());
 
+            // Show the settings window on launch so the app is usable even when
+            // the menu-bar tray icon is hidden behind a crowded menu bar / notch.
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -313,6 +382,15 @@ fn main() {
             switch_profile,
             get_desktop_running_status
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while running tauri application")
+        .run(|app_handle, event| {
+            // Clicking the Dock icon (macOS "reopen") re-shows the settings window.
+            if let tauri::RunEvent::Reopen { .. } = event
+                && let Some(window) = app_handle.get_webview_window("main")
+            {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+        });
 }

--- a/crates/desktop/tauri.conf.json
+++ b/crates/desktop/tauri.conf.json
@@ -6,13 +6,16 @@
     "frontendDist": "./ui"
   },
   "app": {
+    "withGlobalTauri": true,
     "windows": [
       {
         "label": "main",
-        "title": "Claude Desktop Switcher Settings",
-        "width": 640,
-        "height": 520,
-        "resizable": false,
+        "title": "Claude Desktop Switcher",
+        "width": 720,
+        "height": 600,
+        "minWidth": 600,
+        "minHeight": 520,
+        "resizable": true,
         "fullscreen": false,
         "visible": false,
         "center": true

--- a/crates/desktop/ui/index.html
+++ b/crates/desktop/ui/index.html
@@ -3,242 +3,206 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Claude Desktop Switcher 設定</title>
+  <meta name="color-scheme" content="light dark">
+  <title>Claude Desktop Switcher</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
-  <div class="app-container">
-    <!-- Sidebar -->
+  <!-- Inline SVG icon sprite (no external icon library: CSP forbids CDN, no bundler) -->
+  <svg width="0" height="0" class="svg-sprite" aria-hidden="true" focusable="false">
+    <symbol id="i-monitor" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="13" rx="2"/><path d="M9 21h6M12 17v4"/></symbol>
+    <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M7 9l3 3-3 3M13 15h4"/></symbol>
+    <symbol id="i-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></symbol>
+    <symbol id="i-chevron" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"/></symbol>
+    <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V6a2 2 0 0 1 2-2h9"/></symbol>
+    <symbol id="i-duplicate" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><rect x="4" y="4" width="11" height="11" rx="2"/></symbol>
+    <symbol id="i-trash" viewBox="0 0 24 24"><path d="M4 7h16M10 11v6M14 11v6"/><path d="M6 7l1 13a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-13"/><path d="M9 7V4h6v3"/></symbol>
+    <symbol id="i-lock" viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></symbol>
+    <symbol id="i-link" viewBox="0 0 24 24"><path d="M10.5 13.5a4 4 0 0 0 5.7 0l2.3-2.3a4 4 0 0 0-5.7-5.7l-1.1 1.1"/><path d="M13.5 10.5a4 4 0 0 0-5.7 0l-2.3 2.3a4 4 0 0 0 5.7 5.7l1.1-1.1"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24"><path d="M5 12l5 5 9-10"/></symbol>
+    <symbol id="i-info" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 11v5"/><circle cx="12" cy="7.6" r="0.6" fill="currentColor" stroke="none"/></symbol>
+    <symbol id="i-switch" viewBox="0 0 24 24"><path d="M4 9h13l-3-3M20 15H7l3 3"/></symbol>
+  </svg>
+
+  <div class="app">
+    <!-- Left sidebar -->
     <aside class="sidebar">
-      <div class="sidebar-header">
-        <div class="logo-area">
-          <img src="logo.png" id="img-logo" alt="CSW Logo" class="app-logo">
-          <h1>CSW</h1>
-        </div>
-      </div>
-      
-      <div class="profiles-section">
-        <h3>プロファイル</h3>
-        <ul id="profile-list" class="profile-list">
-          <!-- Profiles injected here -->
-        </ul>
+      <div class="wordmark">
+        <img src="logo.png" alt="" class="wordmark-mark">
+        <span class="wordmark-text">Claude Desktop Switcher</span>
       </div>
 
-      <button id="btn-add-profile" class="btn btn-primary add-profile-btn">
-        <span class="icon">+</span> プロファイルを作成
+      <!-- "The Claude you use now" = the user's real, untouched environment (default) -->
+      <button type="button" class="now-claude" id="nowClaude">
+        <span class="now-claude-bezel">
+          <span class="now-claude-icon"><svg class="icon"><use href="#i-monitor"/></svg></span>
+        </span>
+        <span class="now-claude-text">
+          <span class="now-claude-title">いま使っている Claude</span>
+          <span class="now-claude-sub">ふだんの環境。CSW は変更しません</span>
+        </span>
+        <span class="pill pill-active" id="nowClaudeActive" hidden>使用中</span>
+      </button>
+
+      <div class="sidebar-divider"></div>
+
+      <nav class="sidebar-section" id="createdSection" hidden aria-label="作った環境">
+        <h2 class="sidebar-label">作った環境</h2>
+        <ul class="profile-list" id="profileList"></ul>
+      </nav>
+
+      <div class="sidebar-spacer"></div>
+
+      <button type="button" class="btn btn-primary sidebar-create" id="btnCreate">
+        <svg class="icon"><use href="#i-plus"/></svg>
+        <span>環境を作る</span>
       </button>
     </aside>
 
-    <!-- Main Content Area -->
-    <main class="main-content">
-      <!-- Profile Detail Panel -->
-      <section id="profile-details" class="details-panel hidden">
-        <div class="details-header">
-          <div class="profile-badge-large" id="detail-icon-badge">
-            <span id="detail-icon" class="profile-avatar-large">W</span>
-          </div>
-          <div class="profile-title-group">
-            <h2 id="detail-name">Work</h2>
-            <span class="status-tag" id="detail-active-tag">使用中</span>
-          </div>
-        </div>
+    <!-- Right pane: one of empty / detail / create is visible -->
+    <main class="pane">
+      <!-- (a) Empty / welcome -->
+      <section class="view" id="viewEmpty">
+        <div class="view-main">
+          <div class="view-scroll" id="emptyScroll">
+            <div class="view-pad">
+              <div class="empty" id="emptyFirstRun" hidden>
+                <p class="empty-eyebrow">はじめまして</p>
+              </div>
+              <h1 class="empty-title">環境を分けて、混ぜない。</h1>
+              <p class="empty-lead">いまの Claude はそのまま。仕事用や検証用に、独立した Claude 環境を作れます。</p>
 
-        <div class="details-body">
-          <!-- Paths Section -->
-          <div class="info-group">
-            <h3>パス</h3>
-            <div class="path-card">
-              <span class="path-label">Desktop ユーザーデータ</span>
-              <code id="path-desktop">~/.context-switcher-claude/profiles/work/desktop-data</code>
-            </div>
-            <div class="path-card mt-1">
-              <span class="path-label">CLI 設定ディレクトリ</span>
-              <code id="path-cli">~/.context-switcher-claude/profiles/work/cli-data</code>
-            </div>
-          </div>
+              <ol class="steps">
+                <li class="step"><span class="step-num">1</span><span class="step-text"><strong>環境を作る</strong> を押す</span></li>
+                <li class="step"><span class="step-num">2</span><span class="step-text"><strong>まっさらに分ける</strong> か <strong>設定だけ引き継ぐ</strong> を選ぶ</span></li>
+                <li class="step"><span class="step-num">3</span><span class="step-text">メニューバーから切り替える</span></li>
+              </ol>
 
-          <!-- Sharing Matrix -->
-          <div class="info-group mt-2">
-            <h3>設定の共有</h3>
-            <div class="sharing-grid">
-              <div class="sharing-item">
-                <span class="sharing-name">Desktop 設定 (MCP)</span>
-                <span class="sharing-badge" id="share-desktop-config">isolate</span>
-              </div>
-              <div class="sharing-item">
-                <span class="sharing-name">Desktop 一般設定</span>
-                <span class="sharing-badge" id="share-desktop-app-config">isolate</span>
-              </div>
-              <div class="sharing-item">
-                <span class="sharing-name">CLI 設定・フック</span>
-                <span class="sharing-badge" id="share-cli-settings">isolate</span>
-              </div>
-              <div class="sharing-item">
-                <span class="sharing-name">CLAUDE.md (ルール)</span>
-                <span class="sharing-badge" id="share-cli-claude-md">isolate</span>
-              </div>
-              <div class="sharing-item">
-                <span class="sharing-name">CLI プロジェクトメモリ</span>
-                <span class="sharing-badge" id="share-cli-project-memory">isolate</span>
-              </div>
-              <div class="sharing-item">
-                <span class="sharing-name">CLI プラグイン</span>
-                <span class="sharing-badge" id="share-cli-plugins">isolate</span>
-              </div>
-              <div class="sharing-item">
-                <span class="sharing-name">CLI スキル定義</span>
-                <span class="sharing-badge" id="share-cli-skills">isolate</span>
-              </div>
-              <div class="sharing-item">
-                <span class="sharing-name">CLI 会話セッション</span>
-                <span class="sharing-badge" id="share-cli-sessions">isolate</span>
-              </div>
-              <div class="sharing-item">
-                <span class="sharing-name">CLI コマンド履歴</span>
-                <span class="sharing-badge" id="share-cli-history">isolate</span>
-              </div>
-              <div class="sharing-item">
-                <span class="sharing-name">Desktop ワークツリー</span>
-                <span class="sharing-badge" id="share-desktop-worktrees">isolate</span>
-              </div>
-            </div>
-          </div>
-        </div>
+              <button type="button" class="btn btn-primary" id="btnCreateEmpty">
+                <svg class="icon"><use href="#i-plus"/></svg>
+                <span>環境を作る</span>
+              </button>
 
-        <div class="details-footer">
-          <div class="footer-left">
-            <button id="btn-switch" class="btn btn-success">このプロファイルに切り替え</button>
-            <button id="btn-clone" class="btn btn-secondary">複製</button>
-          </div>
-          <button id="btn-delete" class="btn btn-danger">プロファイルを削除</button>
-        </div>
-      </section>
-
-      <!-- Welcome panel (when no profile is selected) -->
-      <section id="welcome-panel" class="welcome-panel">
-        <div class="welcome-icon logo-mark"></div>
-        <h2>Claude Desktop Switcher</h2>
-        <p>サイドバーからプロファイルを選択して詳細を確認するか、新しいプロファイルを作成して複数の Claude 環境を管理できます。</p>
-      </section>
- 
-      <!-- Create Profile Modal -->
-      <div id="modal-create" class="modal hidden">
-        <div class="modal-content">
-          <h2>新しいプロファイルを作成</h2>
-          <div class="form-group">
-            <label for="input-name">プロファイル名</label>
-            <input type="text" id="input-name" placeholder="例: Work, Personal, Research">
-          </div>
-          <div class="form-group">
-            <label for="input-icon">アイコン (絵文字等 - 任意)</label>
-            <input type="text" id="input-icon" placeholder="例: 💼, 🏠, 🧪 (空欄なら頭文字)" maxlength="2">
-          </div>
-          <div class="form-group">
-            <label for="select-preset">設定プリセット</label>
-            <select id="select-preset">
-              <option value="isolate">分離 (独立した設定・メモリ・データ)</option>
-              <option value="share">共有 (MCP・設定・ルールをデフォルトと共有)</option>
-            </select>
-          </div>
-          <div class="modal-buttons">
-            <button id="btn-modal-cancel" class="btn btn-secondary">キャンセル</button>
-            <button id="btn-modal-submit" class="btn btn-primary">作成</button>
-          </div>
-        </div>
-      </div>
- 
-      <!-- Clone Profile Modal -->
-      <div id="modal-clone" class="modal hidden">
-        <div class="modal-content">
-          <h2>プロファイルを複製</h2>
-          <p style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 1rem; line-height: 1.5;">
-            選択中のプロファイルの設定とデータを複製して新しいプロファイルを作成します。ログイン状態は共有設定により異なり、新しいプロファイルで再ログインが必要な場合があります。
-          </p>
-          <div class="form-group">
-            <label for="input-clone-name">新しいプロファイル名</label>
-            <input type="text" id="input-clone-name" placeholder="例: Work-Backup, Personal-Copy">
-          </div>
-          <div class="modal-buttons">
-            <button id="btn-modal-clone-cancel" class="btn btn-secondary">キャンセル</button>
-            <button id="btn-modal-clone-submit" class="btn btn-primary">複製を作成</button>
-          </div>
-        </div>
-      </div>
- 
-      <!-- Onboarding Overlay -->
-      <div id="onboarding-overlay" class="modal hidden">
-        <div class="modal-content onboarding-content">
-          <div class="onboarding-slides">
-            <!-- Slide 1 -->
-            <div class="onboarding-slide" id="slide-1">
-              <div class="onboarding-logo logo-mark"></div>
-              <h2>ようこそ！CSW へ</h2>
-              <p style="font-size: 0.9rem; line-height: 1.6; margin-bottom: 1.5rem;">
-                Claude Desktop Switcher (CSW) は、仕事用・個人用・プロジェクト用など、複数の Claude 環境を安全に切り替えるためのツールです。
-              </p>
-              <div class="onboarding-feature-list">
-                <div class="feature-item">
-                  <span class="feature-icon">-</span>
-                  <div>
-                    <strong>既存の環境は安全です</strong>
-                    <p style="font-size: 0.8rem; color: var(--text-muted); line-height: 1.4;">
-                      現在の設定や会話履歴は「default」プロファイルとして保護されており、一切破壊されません。
-                    </p>
+              <div class="firstrun" id="firstRunExtra" hidden>
+                <div class="firstrun-card">
+                  <div class="firstrun-row">
+                    <span class="firstrun-icon"><svg class="icon"><use href="#i-monitor"/></svg></span>
+                    <div>
+                      <p class="firstrun-head">いまの環境はそのまま残ります</p>
+                      <p class="firstrun-body">あなたが普段使っている Claudeデスクトップアプリと Claude Code の環境は「いま使っている Claude」として保護され、設定・履歴・ログインは変更されません。</p>
+                    </div>
+                  </div>
+                  <div class="firstrun-row">
+                    <span class="firstrun-icon"><svg class="icon"><use href="#i-terminal"/></svg></span>
+                    <div>
+                      <p class="firstrun-head">ターミナルでも同じ環境を使えます</p>
+                      <p class="firstrun-body">Claude Code（CLI）で使うには、ターミナルで次のコマンドを実行します。このタブだけに適用され、普段の環境には影響しません。</p>
+                      <code class="code-line">eval $(csw env "&lt;名前&gt;")</code>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-            <!-- Slide 2 -->
-            <div class="onboarding-slide hidden" id="slide-2">
-              <div class="onboarding-logo logo-mark"></div>
-              <h2>簡単な使い方</h2>
-              <p style="font-size: 0.9rem; line-height: 1.6; margin-bottom: 1.5rem;">
-                プロファイルの切り替えやアプリの終了は、メニューバー（システムトレイ）のアイコンからいつでも簡単に行えます。
-              </p>
-              <div class="onboarding-feature-list">
-                <div class="feature-item">
-                  <span class="feature-icon">-</span>
-                  <div>
-                    <strong>トレイメニューから切替</strong>
-                    <p style="font-size: 0.8rem; color: var(--text-muted); line-height: 1.4;">
-                      メニューからプロファイルを選ぶと、自動的にプロファイルの設定が切り替わり、該当の環境でアプリが立ち上がります。
-                    </p>
+          </div>
+          <div class="view-fade" id="emptyFade" hidden></div>
+        </div>
+      </section>
+
+      <!-- (b) Detail -->
+      <section class="view" id="viewDetail" hidden>
+        <div class="view-main">
+          <div class="view-scroll" id="detailScroll">
+            <div class="view-pad" id="detailContent"></div>
+          </div>
+          <div class="view-fade" id="detailFade" hidden></div>
+        </div>
+        <div class="view-footer" id="detailFooter"></div>
+      </section>
+
+      <!-- (c) Create sheet -->
+      <section class="view" id="viewCreate" hidden>
+        <div class="view-main">
+          <div class="view-scroll" id="createScroll">
+            <div class="view-pad">
+              <h1 class="view-title">新しい環境を作る</h1>
+
+              <div class="field">
+                <label class="field-label" for="inputName">名前</label>
+                <input type="text" id="inputName" class="input" placeholder="例: 仕事用、検証用" autocomplete="off" spellcheck="false">
+                <p class="field-error" id="nameError" hidden></p>
+              </div>
+
+              <div class="field">
+                <label class="field-label" for="inputIcon">アイコン（任意）</label>
+                <input type="text" id="inputIcon" class="input input-icon" placeholder="絵文字や1文字" maxlength="2" autocomplete="off">
+              </div>
+
+              <div class="field">
+                <span class="field-label">どう分けますか?</span>
+                <div class="mode-cards" role="radiogroup" aria-label="分け方">
+                  <label class="mode-card">
+                    <input type="radio" name="mode" value="isolate" checked>
+                    <span class="mode-card-body">
+                      <span class="mode-card-icon"><svg class="icon"><use href="#i-lock"/></svg></span>
+                      <span class="mode-card-main">
+                        <span class="mode-card-head">まっさらに分ける <span class="tag-recommend">推奨</span></span>
+                        <span class="mode-card-desc">ログインも設定も履歴も、ぜんぶゼロから。いまの Claude には一切触れません。</span>
+                        <span class="mode-card-preview">
+                          <span class="prev"><span class="prev-k">ログイン</span><span class="prev-v">新規</span></span>
+                          <span class="prev"><span class="prev-k">設定・履歴</span><span class="prev-v">空</span></span>
+                        </span>
+                      </span>
+                      <span class="mode-card-check"><svg class="icon"><use href="#i-check"/></svg></span>
+                    </span>
+                  </label>
+
+                  <label class="mode-card">
+                    <input type="radio" name="mode" value="share_settings">
+                    <span class="mode-card-body">
+                      <span class="mode-card-icon"><svg class="icon"><use href="#i-link"/></svg></span>
+                      <span class="mode-card-main">
+                        <span class="mode-card-head">設定だけ引き継ぐ</span>
+                        <span class="mode-card-desc">いつもの MCP・ルール・スキルはそのまま使い、ログインと履歴だけ別アカウントにします。</span>
+                        <span class="mode-card-preview">
+                          <span class="prev"><span class="prev-k">ログイン・履歴</span><span class="prev-v">別</span></span>
+                          <span class="prev"><span class="prev-k">MCP・ルール・スキル</span><span class="prev-v">共有</span></span>
+                        </span>
+                      </span>
+                      <span class="mode-card-check"><svg class="icon"><use href="#i-check"/></svg></span>
+                    </span>
+                  </label>
+                </div>
+              </div>
+
+              <div class="advanced">
+                <button type="button" class="advanced-toggle" id="advancedToggle" aria-expanded="false" aria-controls="advancedPanel">
+                  <svg class="icon advanced-chevron"><use href="#i-chevron"/></svg>
+                  <span>詳しく設定する（11項目を個別に）</span>
+                </button>
+                <div class="advanced-panel" id="advancedPanel">
+                  <div class="advanced-inner">
+                    <div class="advanced-head">
+                      <span class="advanced-state" id="advancedState">モードの既定どおり</span>
+                      <button type="button" class="link-reset" id="advancedReset" hidden>モードの既定に戻す</button>
+                    </div>
+                    <div id="advancedGroups"></div>
                   </div>
                 </div>
               </div>
             </div>
-            <!-- Slide 3 -->
-            <div class="onboarding-slide hidden" id="slide-3">
-              <div class="onboarding-logo logo-mark"></div>
-              <h2>ターミナル連携</h2>
-              <p style="font-size: 0.9rem; line-height: 1.6; margin-bottom: 1.5rem;">
-                Claude Code（CLI）でプロファイルを切り替えるには、ターミナルで以下のコマンドを実行します。
-              </p>
-              <div class="path-card" style="margin-bottom: 1rem;">
-                <code style="font-size: 0.85rem;">eval $(csw env &lt;プロファイル名&gt;)</code>
-              </div>
-              <p style="font-size: 0.8rem; color: var(--text-muted); line-height: 1.4;">
-                これにより、そのターミナルセッション内でのみ隔離されたプロファイルが適用されます。
-              </p>
-            </div>
           </div>
-          
-          <div class="onboarding-footer">
-            <div class="slide-dots">
-              <span class="dot active" data-slide="1"></span>
-              <span class="dot" data-slide="2"></span>
-              <span class="dot" data-slide="3"></span>
-            </div>
-            <button id="btn-onboarding-next" class="btn btn-primary">次へ</button>
-          </div>
+          <div class="view-fade" id="createFade" hidden></div>
         </div>
-      </div>
+        <div class="view-footer">
+          <button type="button" class="btn btn-ghost" id="btnCreateCancel">やめる</button>
+          <button type="button" class="btn btn-primary" id="btnCreateSubmit">このプロファイルを作る</button>
+        </div>
+      </section>
     </main>
   </div>
-  
+
+  <div class="toast-area" id="toastArea" aria-live="polite" aria-atomic="false"></div>
+
   <script src="main.js"></script>
 </body>
 </html>

--- a/crates/desktop/ui/main.js
+++ b/crates/desktop/ui/main.js
@@ -1,396 +1,624 @@
 // ============================================================================
-// Claude Desktop Switcher — Frontend Logic (Tauri v2 bindings)
+// Claude Desktop Switcher — settings UI logic (Tauri v2)
+// The WebView is a "dumb terminal": all profile logic lives in Rust.
+// When window.__TAURI__ is absent (plain browser, e.g. screenshots) a dev mock
+// stands in. The shipped app sets withGlobalTauri:true and always reaches Rust.
+//
+// All dynamic UI is built with createElement + textContent (never innerHTML),
+// so backend/user strings are never parsed as HTML — XSS is structurally
+// impossible.
 // ============================================================================
 
-// Helper to safely invoke Tauri commands
-const invoke = window.__TAURI__ ? window.__TAURI__.core.invoke : async (cmd, args) => {
-  console.log(`Mock calling command "${cmd}" with args:`, args);
-  // Mock implementations for design testing
-  if (cmd === 'list_profiles') return [
-    { name: 'default', icon: '', is_default: true },
-    { name: 'Work', icon: '💼', is_default: false },
-    { name: 'Personal', icon: '🏠', is_default: false }
-  ];
-  if (cmd === 'get_active_profile') return 'default';
-  if (cmd === 'get_profile_details') {
-    return {
-      name: args.name,
-      icon: args.name === 'default' ? '' : (args.name === 'Work' ? '💼' : '🏠'),
-      color: '#4A90D9',
-      is_default: args.name === 'default',
-      desktop_path: `~/.context-switcher-claude/profiles/${args.name.toLowerCase()}/desktop-data`,
-      cli_path: `~/.context-switcher-claude/profiles/${args.name.toLowerCase()}/cli-data`,
-      sharing: {
-        desktop_config: 'share',
-        desktop_app_config: 'share',
-        cli_settings: 'share',
-        cli_claude_md: 'share',
-        cli_project_memory: 'isolate',
-        cli_plugins: 'share',
-        cli_skills: 'share',
-        cli_sessions: 'isolate',
-        cli_history: 'isolate',
-        desktop_worktrees: 'isolate',
-        desktop_device_id: 'share'
-      }
-    };
-  }
-  return null;
+const HAS_TAURI = !!(window.__TAURI__ && window.__TAURI__.core);
+const invoke = HAS_TAURI ? window.__TAURI__.core.invoke : devInvoke;
+
+// --- The 11 sharing components, grouped and described in plain language ------
+const SHARE_GROUPS = [
+  {
+    label: 'Claudeデスクトップアプリ',
+    items: [
+      { key: 'desktop_config', name: 'MCP サーバー', desc: '接続済みの MCP サーバー構成' },
+      { key: 'desktop_app_config', name: 'アプリ設定', desc: '表示や挙動などの一般設定' },
+      { key: 'desktop_worktrees', name: 'ワークツリー', desc: 'Git ワークツリーの対応表' },
+    ],
+  },
+  {
+    label: 'Claude Code',
+    items: [
+      { key: 'cli_settings', name: '権限・フック', desc: '許可設定とフック' },
+      { key: 'cli_claude_md', name: 'グローバルルール', desc: 'CLAUDE.md の共通ルール' },
+      { key: 'cli_project_memory', name: 'プロジェクト記憶', desc: 'プロジェクトごとのメモリ' },
+      { key: 'cli_plugins', name: 'プラグイン', desc: 'インストール済みプラグイン' },
+      { key: 'cli_skills', name: 'スキル', desc: 'カスタムスキル定義' },
+      { key: 'cli_sessions', name: '会話履歴', desc: 'これまでの会話セッション' },
+      { key: 'cli_history', name: 'コマンド履歴', desc: '入力したコマンドの履歴' },
+    ],
+  },
+];
+const DEVICE_ID = { key: 'desktop_device_id', name: '端末 ID', desc: '端末を識別するための ID。共有が既定です' };
+const ALL_KEYS = [...SHARE_GROUPS.flatMap((g) => g.items.map((i) => i.key)), DEVICE_ID.key];
+
+// Mode presets (must mirror build_sharing_config in main.rs).
+const PRESETS = {
+  isolate: Object.fromEntries(ALL_KEYS.map((k) => [k, k === 'desktop_device_id' ? 'share' : 'isolate'])),
+  share_settings: {
+    desktop_config: 'share',
+    cli_settings: 'share',
+    cli_claude_md: 'share',
+    cli_plugins: 'share',
+    cli_skills: 'share',
+    desktop_app_config: 'share',
+    desktop_worktrees: 'share',
+    cli_project_memory: 'isolate',
+    cli_sessions: 'isolate',
+    cli_history: 'isolate',
+    desktop_device_id: 'share',
+  },
 };
 
-// DOM State
-let profilesList = [];
-let activeProfileName = 'default';
-let selectedProfileName = null;
+// --- App state --------------------------------------------------------------
+let profiles = [];
+let activeName = 'default';
+let selectedName = null;
+let currentMode = 'isolate';
+let overrides = { ...PRESETS.isolate };
+let advancedCustomized = false;
 
-// DOM Elements
-const elProfileList = document.getElementById('profile-list');
-const elWelcomePanel = document.getElementById('welcome-panel');
-const elDetailsPanel = document.getElementById('profile-details');
+// --- DOM builder helpers (no innerHTML) -------------------------------------
+const SVG_NS = 'http://www.w3.org/2000/svg';
 
-const elDetailIcon = document.getElementById('detail-icon');
-const elDetailName = document.getElementById('detail-name');
-const elDetailActiveTag = document.getElementById('detail-active-tag');
-const elPathDesktop = document.getElementById('path-desktop');
-const elPathCli = document.getElementById('path-cli');
-
-const elShareDesktopConfig = document.getElementById('share-desktop-config');
-const elShareDesktopAppConfig = document.getElementById('share-desktop-app-config');
-const elShareCliSettings = document.getElementById('share-cli-settings');
-const elShareCliClaudeMd = document.getElementById('share-cli-claude-md');
-const elShareCliProjectMemory = document.getElementById('share-cli-project-memory');
-const elShareCliPlugins = document.getElementById('share-cli-plugins');
-const elShareCliSkills = document.getElementById('share-cli-skills');
-const elShareCliSessions = document.getElementById('share-cli-sessions');
-const elShareCliHistory = document.getElementById('share-cli-history');
-const elShareDesktopWorktrees = document.getElementById('share-desktop-worktrees');
-
-const elBtnSwitch = document.getElementById('btn-switch');
-const elBtnClone = document.getElementById('btn-clone');
-const elBtnDelete = document.getElementById('btn-delete');
-const elBtnAddProfile = document.getElementById('btn-add-profile');
-
-// Modal Elements
-const elModalCreate = document.getElementById('modal-create');
-const elInputName = document.getElementById('input-name');
-const elInputIcon = document.getElementById('input-icon');
-const elSelectPreset = document.getElementById('select-preset');
-const elBtnModalCancel = document.getElementById('btn-modal-cancel');
-const elBtnModalSubmit = document.getElementById('btn-modal-submit');
-
-// Clone Modal Elements
-const elModalClone = document.getElementById('modal-clone');
-const elInputCloneName = document.getElementById('input-clone-name');
-const elBtnModalCloneCancel = document.getElementById('btn-modal-clone-cancel');
-const elBtnModalCloneSubmit = document.getElementById('btn-modal-clone-submit');
-
-// Onboarding Elements
-const elOnboardingOverlay = document.getElementById('onboarding-overlay');
-const elBtnOnboardingNext = document.getElementById('btn-onboarding-next');
-
-// Init
-async function init() {
-  await refreshProfiles();
-  setupEventListeners();
-  checkOnboarding();
+function h(tag, props, ...kids) {
+  const node = document.createElement(tag);
+  if (props) {
+    for (const k in props) {
+      const v = props[k];
+      if (v == null || v === false) continue;
+      if (k === 'class') node.className = v;
+      else if (k === 'text') node.textContent = v;
+      else if (k === 'dataset') Object.assign(node.dataset, v);
+      else if (k.startsWith('on') && typeof v === 'function') node.addEventListener(k.slice(2), v);
+      else if (k === 'disabled' || k === 'checked' || k === 'hidden') { if (v) node[k] = true; }
+      else node.setAttribute(k, v);
+    }
+  }
+  appendKids(node, kids);
+  return node;
 }
 
-function checkOnboarding() {
-  const onboarded = localStorage.getItem('csw_onboarded');
-  if (!onboarded) {
-    elOnboardingOverlay.classList.remove('hidden');
-    showSlide(1);
+function appendKids(node, kids) {
+  for (const c of kids.flat(Infinity)) {
+    if (c == null || c === false) continue;
+    node.appendChild(typeof c === 'object' ? c : document.createTextNode(String(c)));
   }
 }
 
-// Fetch and render profiles list
+function icon(id, cls) {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('class', cls || 'icon');
+  const use = document.createElementNS(SVG_NS, 'use');
+  use.setAttribute('href', '#' + id);
+  svg.appendChild(use);
+  return svg;
+}
+
+const $ = (id) => document.getElementById(id);
+function avatarText(p) {
+  return p.icon ? p.icon : (p.name || '?').charAt(0).toUpperCase();
+}
+const reduceMotion = () => matchMedia('(prefers-reduced-motion: reduce)').matches;
+function withTransition(update) {
+  if (document.startViewTransition && !reduceMotion()) document.startViewTransition(update);
+  else update();
+}
+
+// --- DOM refs ---------------------------------------------------------------
+const el = {
+  nowClaude: $('nowClaude'),
+  nowClaudeActive: $('nowClaudeActive'),
+  createdSection: $('createdSection'),
+  profileList: $('profileList'),
+  btnCreate: $('btnCreate'),
+  btnCreateEmpty: $('btnCreateEmpty'),
+  viewEmpty: $('viewEmpty'),
+  viewDetail: $('viewDetail'),
+  viewCreate: $('viewCreate'),
+  detailContent: $('detailContent'),
+  detailFooter: $('detailFooter'),
+  emptyFirstRun: $('emptyFirstRun'),
+  firstRunExtra: $('firstRunExtra'),
+  inputName: $('inputName'),
+  inputIcon: $('inputIcon'),
+  nameError: $('nameError'),
+  advancedToggle: $('advancedToggle'),
+  advancedState: $('advancedState'),
+  advancedReset: $('advancedReset'),
+  advancedGroups: $('advancedGroups'),
+  btnCreateCancel: $('btnCreateCancel'),
+  btnCreateSubmit: $('btnCreateSubmit'),
+  emptyScroll: $('emptyScroll'),
+  emptyFade: $('emptyFade'),
+  detailScroll: $('detailScroll'),
+  detailFade: $('detailFade'),
+  createScroll: $('createScroll'),
+  createFade: $('createFade'),
+  toastArea: $('toastArea'),
+};
+
+// --- Toast ------------------------------------------------------------------
+function showToast(msg, isError) {
+  const t = h('div', { class: 'toast' + (isError ? ' error' : '') },
+    icon(isError ? 'i-info' : 'i-check'), h('span', { text: msg }));
+  if (isError) t.setAttribute('role', 'alert'); // announce failures assertively
+  el.toastArea.appendChild(t);
+  setTimeout(() => {
+    t.style.transition = 'opacity .2s';
+    t.style.opacity = '0';
+    setTimeout(() => t.remove(), 220);
+  }, 3200);
+}
+
+// --- View switching ---------------------------------------------------------
+function setView(view) {
+  el.viewEmpty.hidden = view !== 'empty';
+  el.viewDetail.hidden = view !== 'detail';
+  el.viewCreate.hidden = view !== 'create';
+  requestAnimationFrame(refreshFades);
+}
+
+// --- Sidebar ----------------------------------------------------------------
+function renderSidebar() {
+  el.nowClaudeActive.hidden = activeName !== 'default';
+  el.nowClaude.classList.toggle('selected', selectedName === 'default');
+  el.nowClaude.setAttribute('aria-current', selectedName === 'default' ? 'true' : 'false');
+
+  const created = profiles.filter((p) => p.name !== 'default');
+  el.createdSection.hidden = created.length === 0;
+
+  const rows = created.map((p) => {
+    const open = () => withTransition(() => showDetail(p.name));
+    const li = h('li', {
+      class: 'profile-item' + (p.name === selectedName ? ' selected' : ''),
+      role: 'button', tabindex: '0', onclick: open,
+      onkeydown: (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); } },
+    },
+      h('span', { class: 'profile-avatar', text: avatarText(p) }),
+      h('span', { class: 'profile-name', text: p.name }),
+      p.name === activeName ? h('span', { class: 'pill pill-active', text: '使用中' }) : null);
+    return li;
+  });
+  el.profileList.replaceChildren(...rows);
+}
+
+// --- Detail view ------------------------------------------------------------
+async function showDetail(name) {
+  selectedName = name;
+  let d;
+  try {
+    d = await invoke('get_profile_details', { name });
+  } catch (err) {
+    showToast('プロファイルを読み込めませんでした。', true);
+    return;
+  }
+  renderSidebar();
+  const isDefault = !!d.is_default;
+  const isActive = name === activeName;
+
+  const header = h('div', { class: 'detail-header' },
+    h('div', { class: 'detail-bezel' },
+      h('div', { class: 'detail-avatar', text: d.icon ? d.icon : name.charAt(0).toUpperCase() })),
+    h('div', { class: 'detail-titles' },
+      h('div', { class: 'detail-name', text: isDefault ? 'いま使っている Claude' : name }),
+      h('div', { class: 'detail-tagline', text: isDefault ? 'ふだんの環境。CSW は変更しません' : (isActive ? '使用中の環境' : '作成した環境') })),
+    isActive ? h('span', { class: 'pill pill-active', style: 'margin-left:auto', text: '使用中' }) : null);
+
+  const nodes = [header];
+
+  if (isDefault) {
+    nodes.push(section('', [
+      h('div', { class: 'note-card' },
+        'あなたが普段使っている ', h('strong', { text: 'Claudeデスクトップアプリ' }), 'と ',
+        h('strong', { text: 'Claude Code' }),
+        ' の環境です。CSW はここを表示しているだけで、設定・履歴・ログインを変更したり削除したりしません。切り替えると、いつものこの環境に戻ります。'),
+    ]));
+    nodes.push(pathsSection(d, true));
+    nodes.push(section('共有の状態', [h('div', { class: 'note-card', text: 'すべて元のまま（11 項目すべて共有）。' })]));
+  } else {
+    nodes.push(pathsSection(d, false));
+    nodes.push(sharingDisclosure(d.sharing));
+    nodes.push(terminalSection(name));
+  }
+
+  el.detailContent.replaceChildren(...nodes);
+  renderDetailFooter(name, isDefault, isActive);
+  setView('detail');
+}
+
+function section(label, children) {
+  return h('div', { class: 'section' },
+    label ? h('div', { class: 'section-label', text: label }) : null, ...children);
+}
+
+function pathsSection(d, isDefault) {
+  return section(isDefault ? '場所（本物の Claude フォルダ）' : '場所（このプロファイル）', [
+    pathRow('Claudeデスクトップアプリ', d.desktop_path),
+    pathRow('Claude Code', d.cli_path),
+    isDefault ? h('p', { class: 'path-caption', text: 'これは CSW が作った場所ではなく、あなたの本物の Claude フォルダです。' }) : null,
+  ]);
+}
+
+function pathRow(label, value) {
+  return h('div', { class: 'path-row' },
+    h('div', { class: 'path-meta' },
+      h('span', { class: 'path-label', text: label }),
+      h('code', { class: 'path-code', text: value })),
+    copyButton(value, 'パスをコピー'));
+}
+
+function copyButton(value, title) {
+  return h('button', {
+    type: 'button', class: 'icon-btn', title,
+    onclick: () => copyText(value),
+  }, icon('i-copy'));
+}
+
+function terminalSection(name) {
+  const cmd = `eval $(csw env "${name}")`;
+  return section('ターミナルで使う', [
+    h('div', { class: 'note-card', text: 'Claude Code でこの環境を使うには、ターミナルで次を実行します。このタブだけに適用され、普段の環境には影響しません。' }),
+    h('div', { class: 'path-row', style: 'margin-top:8px' },
+      h('div', { class: 'path-meta' }, h('code', { class: 'path-code', text: cmd })),
+      copyButton(cmd, 'コマンドをコピー')),
+  ]);
+}
+
+function sharingDisclosure(sharing) {
+  let shareCount = 0;
+  for (const k of ALL_KEYS) if (sharing[k] === 'share') shareCount++;
+  const isoCount = ALL_KEYS.length - shareCount;
+
+  const inner = [];
+  for (const g of SHARE_GROUPS) {
+    inner.push(h('div', { class: 'share-group' },
+      h('div', { class: 'share-group-label', text: g.label }),
+      ...g.items.map((it) => sharingReadRow(it, sharing[it.key]))));
+  }
+  inner.push(h('div', { class: 'share-group' }, sharingReadRow(DEVICE_ID, sharing[DEVICE_ID.key])));
+
+  const wrap = h('div', { class: 'disclosure' });
+  const toggle = h('button', {
+    type: 'button', class: 'sharing-summary', 'aria-expanded': 'false',
+    onclick: () => {
+      const open = wrap.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', String(open));
+      innerWrap.inert = !open; // keep collapsed rows out of the tab order
+      requestAnimationFrame(refreshFades);
+    },
+  },
+    h('span', { class: 'summary-text' },
+      `共有 ${shareCount} 件・分離 ${isoCount} 件`,
+      h('span', { class: 'summary-sub', text: ' ／ ログインと履歴は分離' })),
+    icon('i-chevron', 'icon summary-chevron'));
+  const innerWrap = h('div', { class: 'disclosure-inner' }, ...inner);
+  innerWrap.inert = true;
+  appendKids(wrap, [toggle, h('div', { class: 'disclosure-panel' }, innerWrap)]);
+
+  return section('この環境が引き継いでいるもの', [wrap]);
+}
+
+function sharingReadRow(item, mode) {
+  return h('div', { class: 'share-line' },
+    h('div', { class: 'share-line-meta' },
+      h('div', { class: 'share-line-name', text: item.name }),
+      h('div', { class: 'share-line-desc', text: item.desc })),
+    badge(mode));
+}
+
+function badge(mode) {
+  if (mode === 'share') return h('span', { class: 'badge badge-share' }, icon('i-link'), '共有');
+  if (mode === 'copy') return h('span', { class: 'badge badge-copy' }, icon('i-copy'), 'コピー');
+  return h('span', { class: 'badge badge-isolate' }, icon('i-lock'), '分離');
+}
+
+function renderDetailFooter(name, isDefault, isActive) {
+  el.detailFooter.className = 'view-footer split';
+  const switchBtn = h('button', {
+    type: 'button', class: 'btn btn-primary', disabled: isActive,
+    onclick: () => { if (!isActive) doSwitch(name); },
+  }, icon('i-switch'), h('span', { text: isActive ? '使用中の環境' : 'この環境に切り替える' }));
+
+  if (isDefault) {
+    el.detailFooter.replaceChildren(
+      h('span', { class: 'confirm-text', style: 'color:var(--ink-muted)', text: 'この環境は変更・削除できません' }),
+      switchBtn);
+    return;
+  }
+  el.detailFooter.replaceChildren(
+    h('div', { class: 'footer-group' },
+      switchBtn,
+      h('button', { type: 'button', class: 'btn btn-ghost', onclick: () => showCloneRow(name) },
+        icon('i-duplicate'), h('span', { text: '複製' }))),
+    h('button', { type: 'button', class: 'btn btn-danger', onclick: () => showDeleteRow(name) },
+      icon('i-trash'), h('span', { text: '削除' })));
+}
+
+// --- Inline confirm / clone rows (no window.confirm) ------------------------
+function showDeleteRow(name) {
+  el.detailFooter.className = 'view-footer split';
+  const cancel = h('button', { type: 'button', class: 'btn btn-ghost', onclick: () => showDetail(name) }, 'やめる');
+  el.detailFooter.replaceChildren(
+    h('span', { class: 'confirm-text', text: 'この環境を削除します。共有リンクと分離データが消えます。元の Claude には影響しません。' }),
+    h('div', { class: 'footer-group' },
+      cancel,
+      h('button', { type: 'button', class: 'btn btn-danger-solid', onclick: () => doDelete(name) }, '削除する')));
+  cancel.focus(); // default focus on the safe action
+}
+
+function showCloneRow(name) {
+  el.detailFooter.className = 'view-footer';
+  const input = h('input', {
+    type: 'text', class: 'input', placeholder: '複製先の名前（例: 仕事用-控え）',
+    autocomplete: 'off', spellcheck: 'false', style: 'flex:1',
+    onkeydown: (e) => { if (e.key === 'Enter') doClone(name, input.value.trim()); },
+  });
+  el.detailFooter.replaceChildren(
+    input,
+    h('button', { type: 'button', class: 'btn btn-ghost', onclick: () => showDetail(name) }, 'やめる'),
+    h('button', { type: 'button', class: 'btn btn-primary', onclick: () => doClone(name, input.value.trim()) }, '複製を作る'));
+  input.focus();
+}
+
+// --- Backend operations -----------------------------------------------------
+async function doSwitch(name) {
+  try {
+    await invoke('switch_profile', { name, noLaunch: false });
+    await refreshProfiles();
+    withTransition(() => showDetail(name));
+    showToast(`${name === 'default' ? 'いま使っている Claude' : name}に切り替えました`);
+  } catch (err) {
+    showToast('切り替えできませんでした。もう一度お試しください。', true);
+  }
+}
+
+async function doDelete(name) {
+  try {
+    await invoke('delete_profile', { name });
+    selectedName = null;
+    await refreshProfiles();
+    const remaining = profiles.filter((p) => p.name !== 'default');
+    withTransition(() => (remaining.length ? showDetail(remaining[0].name) : showEmpty()));
+    showToast(`${name}を削除しました`);
+  } catch (err) {
+    showToast('削除できませんでした。使用中のプロファイルは切り替えてから削除してください。', true);
+  }
+}
+
+async function doClone(source, target) {
+  const err = validateName(target);
+  if (err) { showToast(err, true); return; }
+  try {
+    await invoke('clone_profile', { source, target });
+    selectedName = target;
+    await refreshProfiles();
+    withTransition(() => showDetail(target));
+    showToast(`${target}を複製しました（元の環境はそのまま）`);
+  } catch (e) {
+    showToast('複製できませんでした。同じ名前がすでにあるか確認してください。', true);
+  }
+}
+
+// --- Empty / create flow ----------------------------------------------------
+function showEmpty() {
+  selectedName = null;
+  renderSidebar();
+  setView('empty');
+}
+
+function showCreate() {
+  localStorage.setItem('csw_onboarded', '1');
+  el.inputName.value = '';
+  el.inputIcon.value = '';
+  el.nameError.hidden = true;
+  setMode('isolate');
+  closeAdvanced();
+  setView('create');
+  setTimeout(() => el.inputName.focus(), 0);
+}
+
+function setMode(mode) {
+  currentMode = mode;
+  const radio = document.querySelector(`input[name="mode"][value="${mode}"]`);
+  if (radio) radio.checked = true;
+  overrides = { ...PRESETS[mode] };
+  advancedCustomized = false;
+  renderAdvancedRows();
+  updateAdvancedState();
+}
+
+function renderAdvancedRows() {
+  const nodes = [];
+  for (const g of SHARE_GROUPS) {
+    nodes.push(h('div', { class: 'share-group' },
+      h('div', { class: 'share-group-label', text: g.label }),
+      ...g.items.map((it) => segRow(it, overrides[it.key], false))));
+  }
+  nodes.push(h('div', { class: 'share-group' },
+    segRow(DEVICE_ID, 'share', true),
+    h('p', { class: 'path-caption', text: '端末識別のため、端末 ID は常に共有されます。' })));
+  el.advancedGroups.replaceChildren(...nodes);
+}
+
+function segRow(item, value, fixed) {
+  const opt = (val, iconId, label) => {
+    const input = h('input', { type: 'radio', name: 'seg-' + item.key, value: val });
+    if (value === val) input.checked = true;
+    if (fixed) input.disabled = true;
+    return h('label', { class: 'seg-opt' }, input, icon(iconId), label);
+  };
+  return h('div', { class: 'share-line' + (fixed ? ' fixed' : '') },
+    h('div', { class: 'share-line-meta' },
+      h('div', { class: 'share-line-name', text: item.name }),
+      h('div', { class: 'share-line-desc', text: item.desc })),
+    h('div', { class: 'seg', role: 'radiogroup', 'aria-label': item.name },
+      opt('share', 'i-link', '共有'), opt('isolate', 'i-lock', '分離'), opt('copy', 'i-copy', 'コピー')));
+}
+
+function updateAdvancedState() {
+  el.advancedState.textContent = advancedCustomized ? 'カスタム設定' : 'モードの既定どおり';
+  el.advancedState.classList.toggle('custom', advancedCustomized);
+  el.advancedReset.hidden = !advancedCustomized;
+}
+
+function openAdvanced() {
+  const adv = el.advancedToggle.closest('.advanced');
+  adv.classList.add('open');
+  el.advancedToggle.setAttribute('aria-expanded', 'true');
+  adv.querySelector('.advanced-inner').inert = false;
+  requestAnimationFrame(refreshFades);
+}
+function closeAdvanced() {
+  const adv = el.advancedToggle.closest('.advanced');
+  adv.classList.remove('open');
+  el.advancedToggle.setAttribute('aria-expanded', 'false');
+  adv.querySelector('.advanced-inner').inert = true; // keep collapsed rows out of the tab order
+}
+
+function validateName(name) {
+  if (!name) return '名前を入力してください。';
+  if (name.toLowerCase() === 'default') return '"default" は使えません。いまの環境を指す予約名です。';
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) return '英数字とハイフン、アンダースコアだけ使えます。';
+  return null;
+}
+
+async function submitCreate() {
+  const name = el.inputName.value.trim();
+  const iconVal = el.inputIcon.value.trim();
+  const err = validateName(name);
+  if (err) { el.nameError.textContent = err; el.nameError.hidden = false; el.inputName.focus(); return; }
+  el.nameError.hidden = true;
+
+  const args = { name, mode: currentMode, icon: iconVal || null };
+  if (advancedCustomized) args.sharingOverrides = { ...overrides };
+
+  el.btnCreateSubmit.disabled = true;
+  try {
+    await invoke('create_profile', args);
+    localStorage.setItem('csw_onboarded', '1');
+    selectedName = name;
+    await refreshProfiles();
+    withTransition(() => showDetail(name));
+    showToast(`${name}を作成しました`);
+  } catch (e) {
+    showToast('作成できませんでした。同じ名前がすでにあるか確認してください。', true);
+  } finally {
+    el.btnCreateSubmit.disabled = false;
+  }
+}
+
+// --- Scroll affordance ------------------------------------------------------
+function fadeFor(scrollEl, fadeEl) {
+  if (!scrollEl || !fadeEl) return;
+  fadeEl.hidden = !(scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight > 4);
+}
+function refreshFades() {
+  fadeFor(el.emptyScroll, el.emptyFade);
+  fadeFor(el.detailScroll, el.detailFade);
+  fadeFor(el.createScroll, el.createFade);
+}
+
+// --- Clipboard --------------------------------------------------------------
+async function copyText(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    showToast('コピーしました');
+  } catch (e) {
+    showToast('コピーできませんでした。', true);
+  }
+}
+
+// --- Data refresh -----------------------------------------------------------
 async function refreshProfiles() {
   try {
-    profilesList = await invoke('list_profiles');
-    activeProfileName = await invoke('get_active_profile');
-    
-    renderProfileList();
-    
-    // Auto-select active profile detail if none is selected
-    if (selectedProfileName && profilesList.some(p => p.name === selectedProfileName)) {
-      await showProfileDetails(selectedProfileName);
-    } else {
-      elDetailsPanel.classList.add('hidden');
-      elWelcomePanel.classList.remove('hidden');
-      selectedProfileName = null;
-    }
-  } catch (err) {
-    console.error('プロファイルの読み込みに失敗しました:', err);
+    profiles = await invoke('list_profiles');
+    activeName = await invoke('get_active_profile');
+  } catch (e) {
+    profiles = [{ name: 'default', icon: '', is_default: true }];
+    activeName = 'default';
   }
+  renderSidebar();
 }
 
-// Render profiles sidebar list
-function renderProfileList() {
-  elProfileList.innerHTML = '';
-  
-  profilesList.forEach(p => {
-    const isActive = p.name === activeProfileName;
-    const iconContent = p.icon ? p.icon : p.name.charAt(0).toUpperCase();
-    
-    const li = document.createElement('li');
-    li.className = `profile-item ${p.name === selectedProfileName ? 'active' : ''}`;
-    li.innerHTML = `
-      <span class="profile-avatar">${iconContent}</span>
-      <span class="profile-name">${p.name}</span>
-      ${isActive ? '<span class="active-dot"></span>' : ''}
-    `;
-    
-    li.addEventListener('click', () => {
-      // Remove active class from previous
-      document.querySelectorAll('.profile-item').forEach(el => el.classList.remove('active'));
-      li.classList.add('active');
-      showProfileDetails(p.name);
-    });
-    
-    elProfileList.appendChild(li);
+// --- Init -------------------------------------------------------------------
+function wireEvents() {
+  el.btnCreate.addEventListener('click', () => withTransition(showCreate));
+  el.btnCreateEmpty.addEventListener('click', () => withTransition(showCreate));
+  el.btnCreateCancel.addEventListener('click', () => withTransition(() =>
+    selectedName ? showDetail(selectedName) : showEmpty()));
+  el.btnCreateSubmit.addEventListener('click', submitCreate);
+  el.nowClaude.addEventListener('click', () => withTransition(() => showDetail('default')));
+
+  document.querySelectorAll('input[name="mode"]').forEach((r) =>
+    r.addEventListener('change', () => {
+      if (advancedCustomized) showToast('モードを変えたので高度設定をリセットしました');
+      setMode(r.value);
+    }));
+
+  el.advancedToggle.addEventListener('click', () => {
+    const open = el.advancedToggle.closest('.advanced').classList.contains('open');
+    if (open) closeAdvanced(); else openAdvanced();
   });
+  el.advancedReset.addEventListener('click', () => setMode(currentMode));
+  el.advancedGroups.addEventListener('change', (e) => {
+    const input = e.target.closest('input[type="radio"]');
+    if (!input || input.disabled) return;
+    overrides[input.name.replace('seg-', '')] = input.value;
+    advancedCustomized = ALL_KEYS.some((k) => overrides[k] !== PRESETS[currentMode][k]);
+    updateAdvancedState();
+  });
+
+  el.emptyScroll.addEventListener('scroll', () => fadeFor(el.emptyScroll, el.emptyFade), { passive: true });
+  el.detailScroll.addEventListener('scroll', () => fadeFor(el.detailScroll, el.detailFade), { passive: true });
+  el.createScroll.addEventListener('scroll', () => fadeFor(el.createScroll, el.createFade), { passive: true });
+  window.addEventListener('resize', refreshFades);
+  el.inputName.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitCreate(); });
 }
 
-// Sharing mode display labels
-function sharingLabel(mode) {
-  return mode === 'share' ? '共有' : '分離';
+function checkFirstRun() {
+  const show = !localStorage.getItem('csw_onboarded');
+  el.emptyFirstRun.hidden = !show;
+  el.firstRunExtra.hidden = !show;
 }
 
-// Load and display profile detailed configuration
-async function showProfileDetails(name) {
-  try {
-    selectedProfileName = name;
-    const p = await invoke('get_profile_details', { name });
-    
-    elWelcomePanel.classList.add('hidden');
-    elDetailsPanel.classList.remove('hidden');
-    
-    // Meta info
-    elDetailIcon.textContent = p.icon ? p.icon : p.name.charAt(0).toUpperCase();
-    elDetailName.textContent = p.name;
-    
-    // Status Tag
-    if (p.name === activeProfileName) {
-      elDetailActiveTag.classList.remove('hidden');
-    } else {
-      elDetailActiveTag.classList.add('hidden');
-    }
-    
-    // Paths
-    elPathDesktop.textContent = p.desktop_path;
-    elPathCli.textContent = p.cli_path;
-    
-    // Sharing Badges
-    updateSharingBadge(elShareDesktopConfig, p.sharing.desktop_config);
-    updateSharingBadge(elShareDesktopAppConfig, p.sharing.desktop_app_config);
-    updateSharingBadge(elShareCliSettings, p.sharing.cli_settings);
-    updateSharingBadge(elShareCliClaudeMd, p.sharing.cli_claude_md);
-    updateSharingBadge(elShareCliProjectMemory, p.sharing.cli_project_memory);
-    updateSharingBadge(elShareCliPlugins, p.sharing.cli_plugins);
-    updateSharingBadge(elShareCliSkills, p.sharing.cli_skills);
-    updateSharingBadge(elShareCliSessions, p.sharing.cli_sessions);
-    updateSharingBadge(elShareCliHistory, p.sharing.cli_history);
-    updateSharingBadge(elShareDesktopWorktrees, p.sharing.desktop_worktrees);
-    
-    // Switch / Delete button states
-    if (p.name === 'default') {
-      elBtnDelete.classList.add('hidden');
-      elBtnClone.classList.add('hidden');
-    } else {
-      elBtnDelete.classList.remove('hidden');
-      elBtnClone.classList.remove('hidden');
-    }
-    
-    if (p.name === activeProfileName) {
-      elBtnSwitch.textContent = '使用中の環境';
-      elBtnSwitch.disabled = true;
-      elBtnSwitch.className = 'btn btn-secondary';
-    } else {
-      elBtnSwitch.textContent = 'このプロファイルに切り替え';
-      elBtnSwitch.disabled = false;
-      elBtnSwitch.className = 'btn btn-success';
-    }
-    
-  } catch (err) {
-    console.error('プロファイル詳細の読み込みに失敗しました:', err);
-  }
+async function init() {
+  wireEvents();
+  await refreshProfiles();
+  checkFirstRun();
+  showEmpty();
 }
 
-function updateSharingBadge(el, mode) {
-  el.textContent = sharingLabel(mode);
-  el.className = `sharing-badge ${mode}`;
-}
-
-// Event Listeners
-function setupEventListeners() {
-  // Create Profile Modal
-  elBtnAddProfile.addEventListener('click', () => {
-    elInputName.value = '';
-    elInputIcon.value = '';
-    elModalCreate.classList.remove('hidden');
-    elInputName.focus();
-  });
-  
-  elBtnModalCancel.addEventListener('click', () => {
-    elModalCreate.classList.add('hidden');
-  });
-  
-  elBtnModalSubmit.addEventListener('click', async () => {
-    const name = elInputName.value.trim();
-    const icon = elInputIcon.value.trim();
-    const mode = elSelectPreset.value;
-    
-    if (!name) {
-      alert('プロファイル名を入力してください。');
-      return;
-    }
-    
-    // Name validations (no default, alphanumeric)
-    if (name.toLowerCase() === 'default') {
-      alert('「default」は予約されたプロファイル名です。');
-      return;
-    }
-    
-    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
-      alert('プロファイル名には英数字、ハイフン、アンダースコアのみ使用できます。');
-      return;
-    }
-    
-    try {
-      await invoke('create_profile', { name, mode, icon: icon || null });
-      elModalCreate.classList.add('hidden');
-      selectedProfileName = name;
-      await refreshProfiles();
-    } catch (err) {
-      alert(`プロファイルの作成に失敗しました: ${err}`);
-    }
-  });
-  
-  // Switching Action
-  elBtnSwitch.addEventListener('click', async () => {
-    if (!selectedProfileName || selectedProfileName === activeProfileName) return;
-    
-    const originalText = elBtnSwitch.textContent;
-    elBtnSwitch.textContent = '切り替え中...';
-    elBtnSwitch.disabled = true;
-    
-    try {
-      await invoke('switch_profile', { name: selectedProfileName, noLaunch: false });
-      await refreshProfiles();
-    } catch (err) {
-      alert(`切り替えに失敗しました: ${err}`);
-      elBtnSwitch.textContent = originalText;
-      elBtnSwitch.disabled = false;
-    }
-  });
-  
-  // Deleting Action
-  elBtnDelete.addEventListener('click', async () => {
-    if (!selectedProfileName || selectedProfileName === 'default') return;
-    if (selectedProfileName === activeProfileName) {
-      alert('使用中のプロファイルは削除できません。先に別のプロファイルに切り替えてください。');
-      return;
-    }
-    
-    if (confirm(`プロファイル「${selectedProfileName}」を削除しますか？\nシンボリックリンクと分離ディレクトリがクリーンアップされます。`)) {
-      try {
-        await invoke('delete_profile', { name: selectedProfileName });
-        selectedProfileName = null;
-        await refreshProfiles();
-      } catch (err) {
-        alert(`削除に失敗しました: ${err}`);
-      }
-    }
-  });
-
-  // Clone Modal Show
-  elBtnClone.addEventListener('click', () => {
-    if (!selectedProfileName) return;
-    elInputCloneName.value = '';
-    elModalClone.classList.remove('hidden');
-    elInputCloneName.focus();
-  });
-
-  elBtnModalCloneCancel.addEventListener('click', () => {
-    elModalClone.classList.add('hidden');
-  });
-
-  elBtnModalCloneSubmit.addEventListener('click', async () => {
-    const name = elInputCloneName.value.trim();
-    if (!name) {
-      alert('プロファイル名を入力してください。');
-      return;
-    }
-
-    if (name.toLowerCase() === 'default') {
-      alert('「default」は予約されたプロファイル名です。');
-      return;
-    }
-
-    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
-      alert('プロファイル名には英数字、ハイフン、アンダースコアのみ使用できます。');
-      return;
-    }
-
-    try {
-      await invoke('clone_profile', { source: selectedProfileName, target: name });
-      elModalClone.classList.add('hidden');
-      selectedProfileName = name;
-      await refreshProfiles();
-    } catch (err) {
-      alert(`プロファイルの複製に失敗しました: ${err}`);
-    }
-  });
-
-  // Onboarding Slides Control
-  let currentSlide = 1;
-  const totalSlides = 3;
-
-  function showSlide(num) {
-    currentSlide = num;
-    for (let i = 1; i <= totalSlides; i++) {
-      const slide = document.getElementById(`slide-${i}`);
-      if (i === num) {
-        slide.classList.remove('hidden');
-      } else {
-        slide.classList.add('hidden');
-      }
-    }
-
-    // Update Dots
-    document.querySelectorAll('.slide-dots .dot').forEach(dot => {
-      if (parseInt(dot.getAttribute('data-slide')) === num) {
-        dot.classList.add('active');
-      } else {
-        dot.classList.remove('active');
-      }
-    });
-
-    // Update Button Text
-    if (num === totalSlides) {
-      elBtnOnboardingNext.textContent = '開始する';
-    } else {
-      elBtnOnboardingNext.textContent = '次へ';
-    }
-  }
-
-  elBtnOnboardingNext.addEventListener('click', () => {
-    if (currentSlide < totalSlides) {
-      showSlide(currentSlide + 1);
-    } else {
-      // End onboarding
-      localStorage.setItem('csw_onboarded', 'true');
-      elOnboardingOverlay.classList.add('hidden');
-    }
-  });
-
-  document.querySelectorAll('.slide-dots .dot').forEach(dot => {
-    dot.addEventListener('click', () => {
-      const target = parseInt(dot.getAttribute('data-slide'));
-      showSlide(target);
-    });
-  });
-}
-
-// Start
 document.addEventListener('DOMContentLoaded', init);
+
+// ============================================================================
+// Dev-only mock (used only when window.__TAURI__ is absent, e.g. screenshots).
+// The shipped app sets withGlobalTauri:true and never reaches this path.
+// ============================================================================
+function devInvoke(cmd, args) {
+  const sample = {
+    default: { name: 'default', icon: '', is_default: true, desktop_path: '~/Library/Application Support/Claude', cli_path: '~/.claude', sharing: Object.fromEntries(ALL_KEYS.map((k) => [k, 'share'])) },
+    仕事用: { name: '仕事用', icon: '💼', is_default: false, desktop_path: '~/.context-switcher-claude/profiles/仕事用/desktop-data', cli_path: '~/.context-switcher-claude/profiles/仕事用/cli-data', sharing: { ...PRESETS.share_settings } },
+    検証用: { name: '検証用', icon: '🧪', is_default: false, desktop_path: '~/.context-switcher-claude/profiles/検証用/desktop-data', cli_path: '~/.context-switcher-claude/profiles/検証用/cli-data', sharing: { ...PRESETS.isolate } },
+  };
+  switch (cmd) {
+    case 'list_profiles':
+      return Promise.resolve([
+        { name: 'default', icon: '', is_default: true },
+        { name: '仕事用', icon: '💼', is_default: false },
+        { name: '検証用', icon: '🧪', is_default: false },
+      ]);
+    case 'get_active_profile':
+      return Promise.resolve('default');
+    case 'get_profile_details':
+      return Promise.resolve(sample[args.name] || sample['検証用']);
+    default:
+      return Promise.resolve(null);
+  }
+}

--- a/crates/desktop/ui/style.css
+++ b/crates/desktop/ui/style.css
@@ -1,589 +1,725 @@
 /* ============================================================================
-   ContextSwitcher for Claude — Premium Glassmorphic Design System
+   Claude Desktop Switcher — Settings UI
+   Warm-monochrome, light/dark via prefers-color-scheme, system fonts (CSP-safe).
+   Design language: minimalist-ui (primary) + high-end-visual-design (restraint).
    ============================================================================ */
 
 :root {
-  --bg-primary: #0b0f19;
-  --bg-secondary: rgba(20, 27, 45, 0.7);
-  --bg-sidebar: rgba(13, 19, 33, 0.85);
-  --text-main: #f3f4f6;
-  --text-muted: #9ca3af;
-  
-  --accent-cyan: #06b6d4;
-  --accent-purple: #8b5cf6;
-  --accent-blue: #3b82f6;
-  --accent-green: #10b981;
-  --accent-red: #ef4444;
+  --canvas:        #F7F6F3;   /* app background — tracks the OS title bar tone */
+  --surface:       #FFFFFF;   /* cards */
+  --surface-alt:   #F2EFE8;   /* inset / the "current Claude" block */
+  --border:        rgba(0, 0, 0, 0.08);
+  --border-strong: rgba(0, 0, 0, 0.14);
+  --ink:           #1F1D1A;   /* body text (never pure black) */
+  --ink-muted:     #6E6B66;
+  --accent:        #C25B3A;   /* single terracotta accent, saturation < 80% */
+  --accent-soft:   #F6EAE4;
+  --accent-ink:    #9F3D22;
+  --ok:            #3F6E4B;   /* "shared" — always paired with icon + word */
+  --ok-soft:       #EDF3EC;
+  --neutral-soft:  #ECEAE4;   /* "isolated" — neutral, not alarming */
+  --danger:        #9F2F2D;
+  --danger-soft:   #FDEBEC;
+  --shadow-soft:   0 1px 2px rgba(40, 36, 32, 0.04), 0 8px 24px rgba(40, 36, 32, 0.06);
+  --radius-card:   12px;
+  --radius-ctl:    6px;
 
-  --border-color: rgba(255, 255, 255, 0.08);
-  --border-hover: rgba(255, 255, 255, 0.15);
-  
-  --font-sans: 'Outfit', -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Segoe UI", Roboto, sans-serif;
-  
-  --shadow-lg: 0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
-  --shadow-glass: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
-  
-  --transition-smooth: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  --font-ui:   -apple-system, "SF Pro Text", "Helvetica Neue", sans-serif;
+  --font-disp: -apple-system, "SF Pro Display", "Helvetica Neue", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", monospace;
+
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+@media (prefers-color-scheme: dark) {
+  :root {
+    --canvas:        #1A1714;
+    --surface:       #221E19;
+    --surface-alt:   #262019;
+    --border:        rgba(255, 255, 255, 0.09);
+    --border-strong: rgba(255, 255, 255, 0.16);
+    --ink:           #EDE9E3;
+    --ink-muted:     #9C948A;
+    --accent:        #E0825E;
+    --accent-soft:   rgba(224, 130, 94, 0.14);
+    --accent-ink:    #E89B79;
+    --ok:            #7FB089;
+    --ok-soft:       rgba(127, 176, 137, 0.14);
+    --neutral-soft:  rgba(255, 255, 255, 0.07);
+    --danger:        #E0807E;
+    --danger-soft:   rgba(224, 128, 126, 0.14);
+    --shadow-soft:   0 1px 2px rgba(0, 0, 0, 0.20), 0 8px 24px rgba(0, 0, 0, 0.28);
+  }
 }
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body { height: 100%; }
 
 body {
-  font-family: var(--font-sans);
-  background: radial-gradient(circle at 50% 50%, #151a30 0%, var(--bg-primary) 100%);
-  color: var(--text-main);
-  height: 100vh;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--ink);
+  background: var(--canvas);
   overflow: hidden;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  line-height: 1.7;
-  word-break: break-word;
-  overflow-wrap: anywhere;
+  -webkit-font-smoothing: antialiased;
 }
 
-/* App Container */
-.app-container {
-  display: flex;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(10, 14, 26, 0.4);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border: 1px solid var(--border-color);
-  overflow: hidden;
+.svg-sprite { position: absolute; width: 0; height: 0; overflow: hidden; }
+
+svg.icon {
+  width: 18px;
+  height: 18px;
+  flex: none;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
-/* Sidebar */
+code, .code-line { font-family: var(--font-mono); }
+
+/* ---------------------------------------------------------------- App shell */
+.app {
+  display: grid;
+  grid-template-columns: 248px 1fr;
+  height: 100dvh;
+}
+
+/* -------------------------------------------------------------------- Sidebar */
 .sidebar {
-  width: 240px;
-  background: var(--bg-sidebar);
-  border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
-  padding: 1.5rem 1rem;
-}
-
-.sidebar-header h1 {
-  font-size: 1.25rem;
-  font-weight: 700;
-  letter-spacing: -0.025em;
-  background: linear-gradient(135deg, var(--accent-cyan), var(--accent-purple));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  margin-bottom: 2rem;
-}
-
-.profiles-section {
-  flex-grow: 1;
+  min-height: 0;
+  flex-shrink: 0;
   overflow-y: auto;
+  padding: 16px 12px;
+  border-right: 1px solid var(--border);
+  background: var(--canvas);
 }
 
-.profiles-section h3 {
-  font-size: 0.75rem;
+.wordmark {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px 14px;
+}
+.wordmark-mark { width: 20px; height: 20px; object-fit: contain; }
+.wordmark-text {
+  font-family: var(--font-disp);
+  font-size: 13px;
   font-weight: 600;
-  letter-spacing: 0.05em;
-  color: var(--text-muted);
-  margin-bottom: 0.75rem;
-  padding-left: 0.5rem;
+  letter-spacing: -0.01em;
+  color: var(--ink);
 }
 
-.profile-list {
-  list-style: none;
+/* "The Claude you use now" — double-bezel, accent stripe, special */
+.now-claude {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px 10px 11px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface-alt);
+  box-shadow: inset 2px 0 0 var(--accent);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  color: var(--ink);
+  transition: border-color 0.15s var(--ease);
 }
+.now-claude:hover { border-color: var(--border-strong); }
+.now-claude.selected { border-color: var(--accent); }
+.now-claude-bezel {
+  flex: none;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 3px;
+}
+.now-claude-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--accent-ink);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+@media (prefers-color-scheme: dark) {
+  .now-claude-icon { box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06); }
+}
+.now-claude-text { min-width: 0; flex: 1; }
+.now-claude-title { display: block; font-size: 12.5px; font-weight: 600; line-height: 1.3; }
+.now-claude-sub { display: block; font-size: 11px; color: var(--ink-muted); line-height: 1.3; }
+
+.sidebar-divider { height: 1px; background: var(--border); margin: 14px 6px; }
+
+.sidebar-section { display: flex; flex-direction: column; min-height: 0; }
+.sidebar-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  padding: 0 6px 8px;
+}
+.profile-list { list-style: none; display: flex; flex-direction: column; gap: 2px; }
 
 .profile-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
+  gap: 10px;
+  height: 44px;
+  padding: 0 10px;
   border-radius: 8px;
   cursor: pointer;
-  margin-bottom: 0.5rem;
-  transition: var(--transition-smooth);
-  border: 1px solid transparent;
+  box-shadow: inset 2px 0 0 transparent;
+  transition: background 0.15s var(--ease);
 }
-
-.profile-item:hover {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: var(--border-color);
+.profile-item:hover { background: var(--surface-alt); }
+.profile-item.selected {
+  background: var(--surface-alt);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
-
-.profile-item.active {
-  background: rgba(6, 182, 212, 0.12);
-  border-color: rgba(6, 182, 212, 0.3);
-}
-
 .profile-avatar {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid var(--border-color);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.7rem;
-  font-weight: 700;
-  color: var(--text-muted);
-  flex-shrink: 0;
-}
-
-.profile-avatar-large {
-  width: 100%;
-  height: 100%;
+  flex: none;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: var(--text-main);
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink-muted);
 }
-
+.profile-item.selected .profile-avatar { background: var(--surface); }
 .profile-name {
-  font-size: 0.95rem;
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
   font-weight: 500;
-  flex-grow: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.active-dot {
-  width: 6px;
-  height: 6px;
-  background-color: var(--accent-cyan);
+.sidebar-spacer { flex: 1; min-height: 12px; }
+.sidebar-create { width: 100%; margin-top: 10px; }
+
+/* --------------------------------------------------------------------- Pane */
+.pane {
+  display: flex;
+  min-width: 0;
+  background: var(--canvas);
+}
+.view {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+.view[hidden] { display: none; }
+.view-main { position: relative; flex: 1; min-height: 0; display: flex; }
+.view-scroll { flex: 1; min-height: 0; overflow-y: auto; }
+.view-pad { padding: 28px 28px 36px; max-width: 640px; }
+.view-fade {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 28px;
+  background: linear-gradient(to top, var(--canvas), transparent);
+  pointer-events: none;
+}
+.view-fade[hidden] { display: none; }
+.view-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border);
+  background: var(--canvas);
+}
+.footer-group { display: flex; align-items: center; gap: 8px; }
+.view-footer.split { justify-content: space-between; }
+
+.view-title {
+  font-family: var(--font-disp);
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-bottom: 18px;
+}
+
+/* ------------------------------------------------------------- Empty state */
+.empty-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent-ink);
+  margin-bottom: 10px;
+}
+.empty-title {
+  font-family: var(--font-disp);
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin-bottom: 10px;
+}
+.empty-lead {
+  font-size: 13.5px;
+  color: var(--ink-muted);
+  max-width: 42ch;
+  margin-bottom: 22px;
+}
+.steps { list-style: none; display: flex; flex-direction: column; gap: 12px; margin-bottom: 24px; }
+.step { display: flex; align-items: flex-start; gap: 12px; }
+.step-num {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
-  box-shadow: 0 0 8px var(--accent-cyan);
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ink-muted);
+  font-variant-numeric: tabular-nums;
+}
+.step-text { font-size: 13px; padding-top: 1px; }
+.step-text strong { font-weight: 600; }
+
+.firstrun { margin-top: 28px; }
+.firstrun-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  background: var(--surface);
+}
+.firstrun-row { display: flex; gap: 12px; align-items: flex-start; }
+.firstrun-icon {
+  flex: none;
+  display: flex; align-items: center; justify-content: center;
+  width: 30px; height: 30px;
+  border-radius: 8px;
+  background: var(--surface-alt);
+  color: var(--accent-ink);
+}
+.firstrun-head { font-size: 13px; font-weight: 600; margin-bottom: 2px; }
+.firstrun-body { font-size: 12px; color: var(--ink-muted); line-height: 1.5; }
+.code-line {
+  display: inline-block;
+  margin-top: 8px;
+  padding: 6px 9px;
+  font-size: 12px;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-ctl);
+  color: var(--ink);
+  word-break: break-all;
 }
 
-/* Buttons */
+/* -------------------------------------------------------------- Detail view */
+.detail-header { display: flex; align-items: center; gap: 14px; margin-bottom: 20px; }
+.detail-bezel {
+  flex: none;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 13px;
+  padding: 4px;
+}
+.detail-avatar {
+  display: flex; align-items: center; justify-content: center;
+  width: 44px; height: 44px;
+  border-radius: 9px;
+  background: var(--surface);
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--accent-ink);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+@media (prefers-color-scheme: dark) {
+  .detail-avatar { box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06); }
+}
+.detail-titles { min-width: 0; }
+.detail-name {
+  font-family: var(--font-disp);
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+.detail-tagline { font-size: 12px; color: var(--ink-muted); margin-top: 2px; }
+
+.section { margin-top: 22px; }
+.section-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  margin-bottom: 10px;
+}
+.note-card {
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  background: var(--surface);
+  font-size: 12.5px;
+  color: var(--ink-muted);
+  line-height: 1.55;
+}
+.note-card strong { color: var(--ink); font-weight: 600; }
+
+.path-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-ctl);
+  background: var(--surface-alt);
+  margin-bottom: 8px;
+}
+.path-row:last-child { margin-bottom: 0; }
+.path-meta { min-width: 0; flex: 1; }
+.path-label { font-size: 11px; color: var(--ink-muted); }
+.path-code { display: block; font-size: 12.5px; color: var(--ink); word-break: break-all; }
+.path-caption { font-size: 11.5px; color: var(--ink-muted); margin-top: 6px; }
+.icon-btn {
+  flex: none;
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-ctl);
+  background: transparent;
+  color: var(--ink-muted);
+  cursor: pointer;
+  transition: background 0.15s var(--ease), color 0.15s var(--ease);
+}
+.icon-btn:hover { background: var(--surface); color: var(--ink); border-color: var(--border); }
+.icon-btn .icon { width: 15px; height: 15px; }
+
+/* Sharing summary + read-only breakdown (detail) */
+.sharing-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  background: var(--surface);
+  cursor: pointer;
+  color: var(--ink);
+  font-family: var(--font-ui);
+  font-size: 13px;
+}
+.sharing-summary:hover { border-color: var(--border-strong); }
+.sharing-summary .summary-text { flex: 1; }
+.sharing-summary .summary-sub { color: var(--ink-muted); font-size: 12px; }
+.summary-chevron { transition: transform 0.2s var(--ease); }
+.disclosure.open .summary-chevron { transform: rotate(90deg); }
+
+.disclosure-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.25s var(--ease);
+}
+.disclosure.open .disclosure-panel { grid-template-rows: 1fr; }
+.disclosure-inner { overflow: hidden; min-height: 0; }
+
+.share-group { margin-top: 14px; }
+.share-group-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  margin-bottom: 6px;
+}
+.share-line {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 4px;
+  border-bottom: 1px solid var(--border);
+}
+.share-line:last-child { border-bottom: 0; }
+.share-line-meta { flex: 1; min-width: 0; }
+.share-line-name { font-size: 12.5px; font-weight: 500; }
+.share-line-desc { font-size: 11px; color: var(--ink-muted); }
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 3px 8px;
+  border-radius: 99px;
+}
+.badge .icon { width: 12px; height: 12px; }
+.badge-share { background: var(--ok-soft); color: var(--ok); }
+.badge-isolate { background: var(--neutral-soft); color: var(--ink-muted); }
+.badge-copy { background: var(--accent-soft); color: var(--accent-ink); }
+
+/* ------------------------------------------------------------- Create form */
+.field { margin-bottom: 18px; }
+.field-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ink);
+  margin-bottom: 6px;
+}
+.input {
+  width: 100%;
+  padding: 9px 11px;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-ctl);
+  transition: border-color 0.15s var(--ease), box-shadow 0.15s var(--ease);
+}
+.input::placeholder { color: var(--ink-muted); }
+.input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.input-icon { width: 96px; text-align: center; }
+.field-error { font-size: 11.5px; color: var(--danger); margin-top: 6px; }
+.field-error[hidden] { display: none; }
+
+/* Mode cards (2 stacked, never a 3-col row) */
+.mode-cards { display: flex; flex-direction: column; gap: 10px; }
+.mode-card { display: block; cursor: pointer; }
+.mode-card input {
+  position: absolute;
+  opacity: 0;
+  width: 0; height: 0;
+}
+.mode-card-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  background: var(--surface);
+  transition: border-color 0.15s var(--ease), box-shadow 0.15s var(--ease);
+}
+.mode-card:has(input:checked) .mode-card-body {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+.mode-card:has(input:focus-visible) .mode-card-body {
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.mode-card-icon {
+  flex: none;
+  display: flex; align-items: center; justify-content: center;
+  width: 34px; height: 34px;
+  border-radius: 8px;
+  background: var(--surface-alt);
+  color: var(--accent-ink);
+}
+.mode-card-main { flex: 1; min-width: 0; }
+.mode-card-head { display: flex; align-items: center; font-size: 15px; font-weight: 600; }
+.tag-recommend {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--accent-ink);
+  background: var(--accent-soft);
+  padding: 1px 6px;
+  border-radius: 4px;
+  margin-left: 8px;
+  letter-spacing: 0.02em;
+}
+.mode-card-desc { display: block; font-size: 12px; color: var(--ink-muted); margin-top: 4px; line-height: 1.5; }
+.mode-card-preview { display: flex; flex-wrap: wrap; gap: 6px 14px; margin-top: 10px; }
+.prev { display: inline-flex; align-items: center; gap: 6px; font-size: 11.5px; }
+.prev-k { color: var(--ink-muted); }
+.prev-v { font-weight: 600; }
+.mode-card-check {
+  flex: none;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.15s var(--ease);
+}
+.mode-card:has(input:checked) .mode-card-check { opacity: 1; }
+
+/* Advanced settings (progressive disclosure, level 2) */
+.advanced { margin-top: 4px; }
+.advanced-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 4px;
+  background: transparent;
+  border: 0;
+  color: var(--ink-muted);
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.advanced-toggle:hover { color: var(--ink); }
+.advanced-chevron { width: 15px; height: 15px; transition: transform 0.2s var(--ease); }
+.advanced.open .advanced-chevron { transform: rotate(90deg); }
+.advanced-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.25s var(--ease);
+}
+.advanced.open .advanced-panel { grid-template-rows: 1fr; }
+.advanced-inner { overflow: hidden; min-height: 0; }
+.advanced-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 0 4px;
+}
+.advanced-state { font-size: 12px; color: var(--ink-muted); }
+.advanced-state.custom { color: var(--accent-ink); font-weight: 600; }
+.link-reset {
+  background: transparent; border: 0; cursor: pointer;
+  font-family: var(--font-ui); font-size: 12px; color: var(--accent-ink);
+}
+.link-reset[hidden] { display: none; }
+
+.seg {
+  display: inline-flex;
+  flex: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-ctl);
+  overflow: hidden;
+}
+.seg-opt {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--ink-muted);
+  cursor: pointer;
+  border-left: 1px solid var(--border);
+}
+.seg-opt:first-child { border-left: 0; }
+.seg-opt .icon { width: 12px; height: 12px; }
+.seg-opt input { position: absolute; opacity: 0; width: 0; height: 0; }
+.seg-opt:has(input:checked) { background: var(--accent-soft); color: var(--accent-ink); }
+.seg-opt:has(input:focus-visible) { box-shadow: inset 0 0 0 2px var(--accent-soft); }
+.share-line.fixed .seg-opt { cursor: default; }
+
+/* -------------------------------------------------------------------- Buttons */
 .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 0.6rem 1rem;
-  font-family: var(--font-sans);
-  font-size: 0.85rem;
-  font-weight: 600;
-  border-radius: 8px;
+  gap: 6px;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  padding: 9px 14px;
+  border-radius: var(--radius-ctl);
   border: 1px solid transparent;
   cursor: pointer;
-  transition: var(--transition-smooth);
   white-space: nowrap;
+  transition: transform 0.12s var(--ease), background 0.15s var(--ease),
+    border-color 0.15s var(--ease), opacity 0.15s var(--ease);
 }
+.btn .icon { width: 16px; height: 16px; }
+.btn:active { transform: scale(0.98); }
+.btn:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--accent-soft); }
+.btn[disabled] { opacity: 0.5; cursor: default; }
+.btn[disabled]:active { transform: none; }
 
-.btn-primary {
-  background: linear-gradient(135deg, var(--accent-blue), var(--accent-purple));
-  color: white;
-  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.25);
-}
+.btn-primary { background: var(--ink); color: var(--canvas); }
+.btn-primary:hover { opacity: 0.88; }
+.btn-ghost { background: transparent; color: var(--ink); border-color: var(--border-strong); }
+.btn-ghost:hover { background: var(--surface-alt); }
+.btn-danger { background: transparent; color: var(--danger); border-color: transparent; }
+.btn-danger:hover { background: var(--danger-soft); }
+.btn-danger-solid { background: var(--danger); color: #fff; }
+.btn-danger-solid:hover { opacity: 0.9; }
 
-.btn-primary:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(139, 92, 246, 0.35);
-}
-
-.btn-secondary {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: var(--border-color);
-  color: var(--text-main);
-}
-
-.btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.12);
-}
-
-.btn-success {
-  background: var(--accent-green);
-  color: white;
-  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.2);
-}
-
-.btn-success:hover {
-  transform: translateY(-1px);
-}
-
-.btn-danger {
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
-  color: var(--accent-red);
-}
-
-.btn-danger:hover {
-  background: var(--accent-red);
-  color: white;
-}
-
-.add-profile-btn {
-  width: 100%;
-  margin-top: 1rem;
-}
-
-/* Main Content Area */
-.main-content {
-  flex-grow: 1;
-  background: var(--bg-secondary);
-  position: relative;
-  display: flex;
-  padding: 2rem;
-}
-
-/* Welcome Panel */
-.welcome-panel {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  width: 100%;
-  max-width: 420px;
-  margin: auto;
-  opacity: 0.85;
-}
-
-.welcome-icon {
-  font-size: 3rem;
-  margin-bottom: 1.5rem;
-  animation: float 4s ease-in-out infinite;
-}
-
-@keyframes float {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-8px); }
-}
-
-.welcome-panel h2 {
-  font-size: 1.5rem;
+.pill {
+  font-size: 10px;
   font-weight: 600;
-  margin-bottom: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 99px;
 }
+.pill-active { background: var(--accent-soft); color: var(--accent-ink); }
 
-.welcome-panel p {
-  color: var(--text-muted);
-  font-size: 0.95rem;
-  line-height: 1.6;
-}
+.confirm-text { font-size: 12.5px; color: var(--ink); flex: 1; min-width: 0; }
 
-/* Details Panel */
-.details-panel {
+/* --------------------------------------------------------------------- Toast */
+.toast-area {
+  position: fixed;
+  right: 16px; bottom: 16px;
   display: flex;
   flex-direction: column;
-  width: 100%;
-  animation: fadeIn 0.35s ease-out;
+  gap: 8px;
+  z-index: 50;
+  pointer-events: none;
 }
-
-@keyframes fadeIn {
-  from { opacity: 0; transform: translateY(5px); }
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 13px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  font-size: 12.5px;
+  color: var(--ink);
+  animation: toast-in 0.2s var(--ease);
+}
+.toast .icon { width: 15px; height: 15px; color: var(--ok); }
+.toast.error .icon { color: var(--danger); }
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
-.details-header {
-  display: flex;
-  align-items: center;
-  gap: 1.25rem;
-  padding-bottom: 1.5rem;
-  border-bottom: 1px solid var(--border-color);
-  margin-bottom: 1.5rem;
+/* ---------------------------------------------------------- View transitions */
+::view-transition-old(root),
+::view-transition-new(root) { animation-duration: 0.2s; }
+
+/* ---------------------------------------------------- Reduced-motion respect */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
+  .advanced-panel, .disclosure-panel { transition: none; }
+  ::view-transition-old(root), ::view-transition-new(root) { animation: none !important; }
 }
-
-.profile-badge-large {
-  width: 48px;
-  height: 48px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.5rem;
-}
-
-.profile-title-group h2 {
-  font-size: 1.4rem;
-  font-weight: 600;
-}
-
-.status-tag {
-  display: inline-block;
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  padding: 0.15rem 0.5rem;
-  border-radius: 99px;
-  background: rgba(6, 182, 212, 0.15);
-  color: var(--accent-cyan);
-  border: 1px solid rgba(6, 182, 212, 0.3);
-  margin-top: 0.25rem;
-}
-
-.details-body {
-  flex-grow: 1;
-  overflow-y: auto;
-}
-
-.info-group h3 {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--text-muted);
-  letter-spacing: 0.02em;
-  margin-bottom: 0.75rem;
-}
-
-.path-card {
-  background: rgba(0, 0, 0, 0.2);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  padding: 0.75rem 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.path-label {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  font-weight: 500;
-}
-
-.path-card code {
-  font-family: SFMono-Regular, Consolas, Monaco, monospace;
-  font-size: 0.85rem;
-  color: var(--accent-cyan);
-  word-break: break-all;
-}
-
-.sharing-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.75rem;
-}
-
-.sharing-item {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  padding: 0.75rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.5rem;
-  min-width: 0;
-}
-
-.sharing-name {
-  font-size: 0.8rem;
-  font-weight: 500;
-  flex-shrink: 1;
-  min-width: 0;
-}
-
-.sharing-badge {
-  font-size: 0.7rem;
-  font-weight: 700;
-  padding: 0.2rem 0.5rem;
-  border-radius: 6px;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.sharing-badge.isolate {
-  background: rgba(139, 92, 246, 0.15);
-  color: #a78bfa;
-  border: 1px solid rgba(139, 92, 246, 0.3);
-}
-
-.sharing-badge.share {
-  background: rgba(16, 185, 129, 0.15);
-  color: #34d399;
-  border: 1px solid rgba(16, 185, 129, 0.3);
-}
-
-.details-footer {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 1.5rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid var(--border-color);
-}
-
-/* Modal */
-.modal {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(7, 10, 19, 0.8);
-  backdrop-filter: blur(8px);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 100;
-  transition: var(--transition-smooth);
-}
-
-.modal-content {
-  background: #111827;
-  border: 1px solid var(--border-color);
-  border-radius: 16px;
-  padding: 2rem;
-  width: 100%;
-  max-width: 380px;
-  box-shadow: var(--shadow-lg);
-  animation: modalSlide 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-@keyframes modalSlide {
-  from { transform: translateY(15px); opacity: 0; }
-  to { transform: translateY(0); opacity: 1; }
-}
-
-.modal h2 {
-  font-size: 1.25rem;
-  font-weight: 600;
-  margin-bottom: 1.5rem;
-}
-
-.form-group {
-  margin-bottom: 1.25rem;
-}
-
-.form-group label {
-  display: block;
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  font-weight: 600;
-  margin-bottom: 0.5rem;
-}
-
-.form-group input, .form-group select {
-  width: 100%;
-  padding: 0.65rem 0.75rem;
-  background: rgba(0, 0, 0, 0.25);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  color: white;
-  font-family: var(--font-sans);
-  font-size: 0.875rem;
-  transition: var(--transition-smooth);
-}
-
-.form-group input:focus, .form-group select:focus {
-  outline: none;
-  border-color: var(--accent-cyan);
-  box-shadow: 0 0 0 2px rgba(6, 182, 212, 0.2);
-}
-
-.modal-buttons {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.75rem;
-  margin-top: 2rem;
-}
-
-/* Helpers */
-.hidden {
-  display: none !important;
-}
-
-.mt-1 { margin-top: 0.5rem; }
-.mt-2 { margin-top: 1rem; }
-
-/* Sidebar Logo Area */
-.logo-area {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 2rem;
-}
-
-.app-logo {
-  width: 28px;
-  height: 28px;
-  object-fit: contain;
-}
-
-.sidebar-header .logo-area h1 {
-  font-size: 1.4rem;
-  font-weight: 700;
-  letter-spacing: -0.025em;
-  background: linear-gradient(135deg, var(--accent-cyan), var(--accent-purple));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  margin-bottom: 0;
-}
-
-/* Footer layout */
-.footer-left {
-  display: flex;
-  gap: 0.5rem;
-}
-
-/* Onboarding style */
-.onboarding-content {
-  max-width: 440px !important;
-  padding: 2.5rem !important;
-  text-align: center;
-}
-
-.onboarding-logo {
-  font-size: 3.5rem;
-  margin-bottom: 1rem;
-}
-
-.onboarding-slide h2 {
-  font-size: 1.5rem;
-  font-weight: 600;
-  margin-bottom: 1rem;
-}
-
-.onboarding-feature-list {
-  text-align: left;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  padding: 1rem;
-  margin-top: 1rem;
-}
-
-.feature-item {
-  display: flex;
-  gap: 0.75rem;
-  align-items: flex-start;
-}
-
-.feature-icon {
-  font-size: 1.25rem;
-}
-
-.onboarding-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 2.5rem;
-}
-
-.slide-dots {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.slide-dots .dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.2);
-  cursor: pointer;
-  transition: var(--transition-smooth);
-}
-
-.slide-dots .dot.active {
-  background: var(--accent-cyan);
-  box-shadow: 0 0 8px var(--accent-cyan);
-  width: 20px;
-  border-radius: 4px;
-}
-


### PR DESCRIPTION
## 背景 / 根本原因

配布版の設定GUIが**実バックエンドに接続されておらず**、`main.js` のモック(偽の `default`/`Work`/`Personal`・偽パス・勝手な分離共有)を表示していた。原因は `tauri.conf.json` に `app.withGlobalTauri` が無く Tauri v2 で `window.__TAURI__` が注入されないこと(公式 docs で確認)。これにより「default が既存 Claude と違う配置」「サンプルが使えない」「分離/共有が勝手」というユーザー混乱が発生していた。あわせて、設定画面のUX(初手で11項目が細分表示・スクロールに設定が隠れる・ダーク固定でタイトルバー不整合・スキル非準拠)が破綻していた。

## アプローチ

スキル(`minimalist-ui` / `high-end-visual-design` / `redesign-existing-projects` / `google-modern-web-guidance` / `official-terminology`)を一次情報として精読し、設定画面特有のUXベストプラクティス調査とLPの利用シーン(完全分離 / 部分共有 / マルチアカウント / ターミナル連携)をジャーニーに落としたブループリントに沿って再設計した。

## 主な変更

- **実データ接続**: `withGlobalTauri:true` を追加し `window.__TAURI__` 経由で実プロファイルを表示(モックは無Tauri時=スクショ用のみ)。
- **概念モデル**: `default` を「いま使っている Claude」として特別表示(独立ブロック・実パス `~/Library/Application Support/Claude` / `~/.claude`・複製/削除を非描画・全項目共有を1行サマリ・非破壊を明示)。
- **2モード化**: 新規作成を「まっさらに分ける(既定/推奨)」「設定だけ引き継ぐ」に集約。11項目の個別指定は「高度な設定」へ段階開示。`create_profile` に mode プリセット(設定資産7項目Share / 記憶・履歴・ログインはIsolate、`cli_skills`/`desktop_app_config` の漏れ修正)+ `sharing_overrides` を実装。
- **視覚再設計**: warm monochrome + `prefers-color-scheme` でライト/ダーク両対応、単色 canvas + `color-scheme` meta でタイトルバーと一致(ダーク固定 glass を撤去)。システムフォント化(CSPでブロックされる Google Fonts を廃止)。
- **ウィンドウ/スクロール**: 720x600・resizable・2ペイン独立スクロール・sticky footer・下端フェードで「設定が下にあると気づけない」を構造解消。
- **操作系**: `window.alert/confirm` を全廃しインラインエラー・削除/複製確認row・トーストに(削除確認の既定フォーカスは安全側)。`inert` で折り畳みパネルのキーボードフォーカス漏れ防止。View Transitions は能力検知。
- **セキュリティ**: 動的UIは `innerHTML` を使わず `createElement`/`textContent`/`createElementNS` で構築し XSS を構造排除。
- 起動時/Dock再開/閉じる時のウィンドウ表示制御。

## 検証

- `cargo fmt` / `cargo clippy --workspace --all-targets -D warnings` / `cargo test --workspace`(18件)green。
- ヘッドレス Chrome でライト/ダーク両テーマ × 主要状態(空状態/初回オンボーディング/default詳細/プロファイル詳細(共有内訳)/作成シート2モード+高度設定)をレンダ目視。
- 3観点(スキルpre-flight / ユーザー8不満・ストーリー最短手順 / コード正当性)の敵対的レビューを実施し、must-fix(公式用語のスペース)・should-fix(inert・削除後遷移・モード切替時のカスタム破棄警告・エラートーストassertive)を反映。

## 残課題(別PR)

- LP / USER_GUIDE のスクリーンショットを新UIで再生成(現状は旧UIのまま)。EN ガイドの整合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)