### PR TITLE
fix(desktop,website): トレイ絵文字撤去とモバイルのセクション余白崩れ修正

### DIFF
--- a/crates/desktop/src/main.rs
+++ b/crates/desktop/src/main.rs
@@ -234,14 +234,9 @@ fn update_tray_menu(app: &AppHandle) -> Result<(), String> {
     let mut menu_items = Vec::new();
 
     // 1. Title Item
-    let title_item = MenuItem::with_id(
-        app,
-        "title",
-        "🔵 Claude Desktop Switcher",
-        false,
-        None::<&str>,
-    )
-    .map_err(|e| e.to_string())?;
+    let title_item =
+        MenuItem::with_id(app, "title", "Claude Desktop Switcher", false, None::<&str>)
+            .map_err(|e| e.to_string())?;
     menu_items.push(Box::new(title_item) as Box<dyn tauri::menu::IsMenuItem<Wry>>);
 
     let sep1 = PredefinedMenuItem::separator(app).map_err(|e| e.to_string())?;
@@ -271,7 +266,7 @@ fn update_tray_menu(app: &AppHandle) -> Result<(), String> {
     let sep2 = PredefinedMenuItem::separator(app).map_err(|e| e.to_string())?;
     menu_items.push(Box::new(sep2) as Box<dyn tauri::menu::IsMenuItem<Wry>>);
 
-    let settings_item = MenuItem::with_id(app, "settings", "⚙ 設定...", true, None::<&str>)
+    let settings_item = MenuItem::with_id(app, "settings", "設定...", true, None::<&str>)
         .map_err(|e| e.to_string())?;
     menu_items.push(Box::new(settings_item) as Box<dyn tauri::menu::IsMenuItem<Wry>>);
 

--- a/website/style.css
+++ b/website/style.css
@@ -775,8 +775,12 @@ html[lang="ja"] .faq-header h2 {
    is intentionally left unchanged; these rules only fix overflow/oversized
    typography and the header/hero/button arrangement on narrow viewports. */
 @media (max-width: 768px) {
+    /* Horizontal-only: the `padding` shorthand here previously zeroed each
+       section's vertical padding on mobile, collapsing the spacing between
+       sections (e.g. the hero image and the heading below it). */
     .container {
-        padding: 0 20px;
+        padding-left: 20px;
+        padding-right: 20px;
     }
 
     /* Header: there is no room for in-page anchors without a menu, so drop
@@ -853,7 +857,8 @@ html[lang="ja"] .faq-header h2 {
 
 @media (max-width: 480px) {
     .container {
-        padding: 0 16px;
+        padding-left: 16px;
+        padding-right: 16px;
     }
     .headline {
         font-size: 2.25rem;


### PR DESCRIPTION
2件の残作業をまとめて対応。

## desktop: トレイメニューの絵文字撤去
システムトレイメニューの装飾絵文字（タイトルの 🔵、設定項目の ⚙）を撤去し、AGENTS.md の反絵文字ルールに統一。使用中/非使用を示す ●/○ は機能的指標として維持。

## website: モバイルのセクション余白崩れ修正
モバイルの `.container` が `padding: 0 20px` / `0 16px`（ショートハンド）で各セクションの**縦パディングまで 0 に上書き**しており、ヒーロー画像と直下の見出しなどセクション間の余白が潰れていた（ヘッドレス実測でギャップ **3px**）。左右パディングのみの指定に変更し、設計どおりの縦リズムを回復（**約99px** に。hero→features だけでなく全セクションのモバイル余白が回復）。デスクトップ表示は不変、JA/EN 共有 CSS。

## 検証
- `cargo fmt --check` / `clippy -D warnings` / `test`(desktop) green。
- ヘッドレス Chrome(390px) で hero→features ギャップを実測（3px→99px）し目視確認。
- マージ後に Pages 再デプロイ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)