### PR TITLE
fix(desktop): アイコンをPhosphorに置換し選択フォーカスのスロップを排除

### DIFF
--- a/crates/desktop/ui/index.html
+++ b/crates/desktop/ui/index.html
@@ -9,19 +9,22 @@
 </head>
 <body>
   <!-- Inline SVG icon sprite (no external icon library: CSP forbids CDN, no bundler) -->
+  <!-- Icons: Phosphor (regular weight), MIT License (c) 2023 Phosphor Icons.
+       Vendored as a local sprite because the bundled app has no bundler and the
+       CSP is default-src 'self' (no CDN). Skill-recommended family over hand-rolled SVG. -->
   <svg width="0" height="0" class="svg-sprite" aria-hidden="true" focusable="false">
-    <symbol id="i-monitor" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="13" rx="2"/><path d="M9 21h6M12 17v4"/></symbol>
-    <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M7 9l3 3-3 3M13 15h4"/></symbol>
-    <symbol id="i-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></symbol>
-    <symbol id="i-chevron" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"/></symbol>
-    <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V6a2 2 0 0 1 2-2h9"/></symbol>
-    <symbol id="i-duplicate" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><rect x="4" y="4" width="11" height="11" rx="2"/></symbol>
-    <symbol id="i-trash" viewBox="0 0 24 24"><path d="M4 7h16M10 11v6M14 11v6"/><path d="M6 7l1 13a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-13"/><path d="M9 7V4h6v3"/></symbol>
-    <symbol id="i-lock" viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></symbol>
-    <symbol id="i-link" viewBox="0 0 24 24"><path d="M10.5 13.5a4 4 0 0 0 5.7 0l2.3-2.3a4 4 0 0 0-5.7-5.7l-1.1 1.1"/><path d="M13.5 10.5a4 4 0 0 0-5.7 0l-2.3 2.3a4 4 0 0 0 5.7 5.7l1.1-1.1"/></symbol>
-    <symbol id="i-check" viewBox="0 0 24 24"><path d="M5 12l5 5 9-10"/></symbol>
-    <symbol id="i-info" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 11v5"/><circle cx="12" cy="7.6" r="0.6" fill="currentColor" stroke="none"/></symbol>
-    <symbol id="i-switch" viewBox="0 0 24 24"><path d="M4 9h13l-3-3M20 15H7l3 3"/></symbol>
+    <symbol id="i-monitor" viewBox="0 0 256 256"><path d="M208,40H48A24,24,0,0,0,24,64V176a24,24,0,0,0,24,24H208a24,24,0,0,0,24-24V64A24,24,0,0,0,208,40Zm8,136a8,8,0,0,1-8,8H48a8,8,0,0,1-8-8V64a8,8,0,0,1,8-8H208a8,8,0,0,1,8,8Zm-48,48a8,8,0,0,1-8,8H96a8,8,0,0,1,0-16h64A8,8,0,0,1,168,224Z"/></symbol>
+    <symbol id="i-terminal" viewBox="0 0 256 256"><path d="M128,128a8,8,0,0,1-3,6.25l-40,32a8,8,0,1,1-10-12.5L107.19,128,75,102.25a8,8,0,1,1,10-12.5l40,32A8,8,0,0,1,128,128Zm48,24H136a8,8,0,0,0,0,16h40a8,8,0,0,0,0-16Zm56-96V200a16,16,0,0,1-16,16H40a16,16,0,0,1-16-16V56A16,16,0,0,1,40,40H216A16,16,0,0,1,232,56ZM216,200V56H40V200H216Z"/></symbol>
+    <symbol id="i-plus" viewBox="0 0 256 256"><path d="M224,128a8,8,0,0,1-8,8H136v80a8,8,0,0,1-16,0V136H40a8,8,0,0,1,0-16h80V40a8,8,0,0,1,16,0v80h80A8,8,0,0,1,224,128Z"/></symbol>
+    <symbol id="i-chevron" viewBox="0 0 256 256"><path d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z"/></symbol>
+    <symbol id="i-copy" viewBox="0 0 256 256"><path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/></symbol>
+    <symbol id="i-duplicate" viewBox="0 0 256 256"><path d="M184,64H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H184a8,8,0,0,0,8-8V72A8,8,0,0,0,184,64Zm-8,144H48V80H176ZM224,40V184a8,8,0,0,1-16,0V48H72a8,8,0,0,1,0-16H216A8,8,0,0,1,224,40Z"/></symbol>
+    <symbol id="i-trash" viewBox="0 0 256 256"><path d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"/></symbol>
+    <symbol id="i-lock" viewBox="0 0 256 256"><path d="M208,80H176V56a48,48,0,0,0-96,0V80H48A16,16,0,0,0,32,96V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V96A16,16,0,0,0,208,80ZM96,56a32,32,0,0,1,64,0V80H96ZM208,208H48V96H208V208Z"/></symbol>
+    <symbol id="i-link" viewBox="0 0 256 256"><path d="M240,88.23a54.43,54.43,0,0,1-16,37L189.25,160a54.27,54.27,0,0,1-38.63,16h-.05A54.63,54.63,0,0,1,96,119.84a8,8,0,0,1,16,.45A38.62,38.62,0,0,0,150.58,160h0a38.39,38.39,0,0,0,27.31-11.31l34.75-34.75a38.63,38.63,0,0,0-54.63-54.63l-11,11A8,8,0,0,1,135.7,59l11-11A54.65,54.65,0,0,1,224,48,54.86,54.86,0,0,1,240,88.23ZM109,185.66l-11,11A38.41,38.41,0,0,1,70.6,208h0a38.63,38.63,0,0,1-27.29-65.94L78,107.31A38.63,38.63,0,0,1,144,135.71a8,8,0,0,0,16,.45A54.86,54.86,0,0,0,144,96a54.65,54.65,0,0,0-77.27,0L32,130.75A54.62,54.62,0,0,0,70.56,224h0a54.28,54.28,0,0,0,38.64-16l11-11A8,8,0,0,0,109,185.66Z"/></symbol>
+    <symbol id="i-check" viewBox="0 0 256 256"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></symbol>
+    <symbol id="i-info" viewBox="0 0 256 256"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm16-40a8,8,0,0,1-8,8,16,16,0,0,1-16-16V128a8,8,0,0,1,0-16,16,16,0,0,1,16,16v40A8,8,0,0,1,144,176ZM112,84a12,12,0,1,1,12,12A12,12,0,0,1,112,84Z"/></symbol>
+    <symbol id="i-switch" viewBox="0 0 256 256"><path d="M213.66,181.66l-32,32a8,8,0,0,1-11.32-11.32L188.69,184H48a8,8,0,0,1,0-16H188.69l-18.35-18.34a8,8,0,0,1,11.32-11.32l32,32A8,8,0,0,1,213.66,181.66Zm-139.32-64a8,8,0,0,0,11.32-11.32L67.31,88H208a8,8,0,0,0,0-16H67.31L85.66,53.66A8,8,0,0,0,74.34,42.34l-32,32a8,8,0,0,0,0,11.32Z"/></symbol>
   </svg>
 
   <div class="app">

--- a/crates/desktop/ui/main.js
+++ b/crates/desktop/ui/main.js
@@ -610,15 +610,15 @@ document.addEventListener('DOMContentLoaded', init);
 function devInvoke(cmd, args) {
   const sample = {
     default: { name: 'default', icon: '', is_default: true, desktop_path: '~/Library/Application Support/Claude', cli_path: '~/.claude', sharing: Object.fromEntries(ALL_KEYS.map((k) => [k, 'share'])) },
-    仕事用: { name: '仕事用', icon: '💼', is_default: false, desktop_path: '~/.context-switcher-claude/profiles/仕事用/desktop-data', cli_path: '~/.context-switcher-claude/profiles/仕事用/cli-data', sharing: { ...PRESETS.share_settings } },
-    検証用: { name: '検証用', icon: '🧪', is_default: false, desktop_path: '~/.context-switcher-claude/profiles/検証用/desktop-data', cli_path: '~/.context-switcher-claude/profiles/検証用/cli-data', sharing: { ...PRESETS.isolate } },
+    仕事用: { name: '仕事用', icon: '', is_default: false, desktop_path: '~/.context-switcher-claude/profiles/仕事用/desktop-data', cli_path: '~/.context-switcher-claude/profiles/仕事用/cli-data', sharing: { ...PRESETS.share_settings } },
+    検証用: { name: '検証用', icon: '', is_default: false, desktop_path: '~/.context-switcher-claude/profiles/検証用/desktop-data', cli_path: '~/.context-switcher-claude/profiles/検証用/cli-data', sharing: { ...PRESETS.isolate } },
   };
   switch (cmd) {
     case 'list_profiles':
       return Promise.resolve([
         { name: 'default', icon: '', is_default: true },
-        { name: '仕事用', icon: '💼', is_default: false },
-        { name: '検証用', icon: '🧪', is_default: false },
+        { name: '仕事用', icon: '', is_default: false },
+        { name: '検証用', icon: '', is_default: false },
       ]);
     case 'get_active_profile':
       return Promise.resolve('default');

--- a/crates/desktop/ui/style.css
+++ b/crates/desktop/ui/style.css
@@ -76,6 +76,22 @@ svg.icon {
   stroke: none;
 }
 
+/* Focus: the UA default is a generic blue "auto" ring (the AI-default selection
+   look). Suppress it on pointer interaction so a tap shows only the element's own
+   selected/active styling, and give keyboard users an intentional ring in the
+   warm accent instead of the blue one. */
+:focus:not(:focus-visible) { outline: none; }
+.profile-item:focus-visible,
+.now-claude:focus-visible,
+.sharing-summary:focus-visible,
+.advanced-toggle:focus-visible,
+.icon-btn:focus-visible,
+.link-reset:focus-visible,
+.disclosure-inner [data-disclosure-toggle]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 code, .code-line { font-family: var(--font-mono); }
 
 /* ---------------------------------------------------------------- App shell */

--- a/crates/desktop/ui/style.css
+++ b/crates/desktop/ui/style.css
@@ -72,11 +72,8 @@ svg.icon {
   width: 18px;
   height: 18px;
   flex: none;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 1.5;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+  fill: currentColor; /* Phosphor icons are filled paths, not stroked */
+  stroke: none;
 }
 
 code, .code-line { font-family: var(--font-mono); }


### PR DESCRIPTION
## 背景
「アイコンは（Reactなら Phosphor 等の）ちゃんとしたセットを使いたい。絵文字は素人感が強い」という指摘。スキルもアイコンは **Phosphor / Radix** を指定し、**絵文字禁止**・**手描きSVG非推奨**（design-taste §3.C「NEVER hand-roll SVG」）としている。これまでの実装は chrome アイコンを手描きインラインSVGで賄っていた。

## 対応
- 全12アイコンを**公式 Phosphor（regular weight, MIT）**の SVG に置換。バンドラ無し・CSP `default-src 'self'`（CDN不可）の制約下でも proper icon family を使えるよう、**ローカル sprite として同梱**（self-hosted）。MIT 帰属コメントを sprite に記載。
- `svg.icon` を stroke ベース → **fill ベース**（Phosphor は塗りパス）に変更。サイズ指定は維持。
- モックの sample プロファイルから絵文字（💼🧪）を除去し頭文字表示に（実アプリのアイコン任意入力は維持）。

## スキル根拠
minimalist-ui §6（Phosphor/Radix・stroke統一）/ high-end §2（ultra-light precise lines, Phosphor）/ design-taste §3.C（Phosphor 優先・hand-roll 禁止・1ファミリ）/ redesign Iconography（Phosphor へ）。

## 検証
- ヘッドレスでライト/ダーク両テーマの create(高度設定の segmented 含む)/detail を実レンダ目視。全アイコンが Phosphor で一貫表示。
- 手描き(24x24)シンボル 0、Phosphor(256x256)シンボル 12 を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)