### PR TITLE
fix(desktop): インタラクティブ要素に押下(:active)フィードバックを追加(スキル準拠)

### DIFF
--- a/crates/desktop/ui/style.css
+++ b/crates/desktop/ui/style.css
@@ -143,9 +143,10 @@ code, .code-line { font-family: var(--font-mono); }
   cursor: pointer;
   font-family: var(--font-ui);
   color: var(--ink);
-  transition: border-color 0.15s var(--ease);
+  transition: border-color 0.15s var(--ease), transform 0.12s var(--ease);
 }
 .now-claude:hover { border-color: var(--border-strong); }
+.now-claude:active { transform: scale(0.99); }
 .now-claude.selected { border-color: var(--accent); }
 .now-claude-bezel {
   flex: none;
@@ -194,9 +195,10 @@ code, .code-line { font-family: var(--font-mono); }
   border-radius: 8px;
   cursor: pointer;
   box-shadow: inset 2px 0 0 transparent;
-  transition: background 0.15s var(--ease);
+  transition: background 0.15s var(--ease), transform 0.12s var(--ease);
 }
 .profile-item:hover { background: var(--surface-alt); }
+.profile-item:active { transform: scale(0.99); }
 .profile-item.selected {
   background: var(--surface-alt);
   box-shadow: inset 2px 0 0 var(--accent);
@@ -425,9 +427,10 @@ code, .code-line { font-family: var(--font-mono); }
   background: transparent;
   color: var(--ink-muted);
   cursor: pointer;
-  transition: background 0.15s var(--ease), color 0.15s var(--ease);
+  transition: background 0.15s var(--ease), color 0.15s var(--ease), transform 0.12s var(--ease);
 }
 .icon-btn:hover { background: var(--surface); color: var(--ink); border-color: var(--border); }
+.icon-btn:active { transform: scale(0.92); }
 .icon-btn .icon { width: 15px; height: 15px; }
 
 /* Sharing summary + read-only breakdown (detail) */
@@ -445,8 +448,10 @@ code, .code-line { font-family: var(--font-mono); }
   color: var(--ink);
   font-family: var(--font-ui);
   font-size: 13px;
+  transition: border-color 0.15s var(--ease), transform 0.12s var(--ease);
 }
 .sharing-summary:hover { border-color: var(--border-strong); }
+.sharing-summary:active { transform: scale(0.995); }
 .sharing-summary .summary-text { flex: 1; }
 .sharing-summary .summary-sub { color: var(--ink-muted); font-size: 12px; }
 .summary-chevron { transition: transform 0.2s var(--ease); }
@@ -597,11 +602,13 @@ code, .code-line { font-family: var(--font-mono); }
   background: transparent;
   border: 0;
   color: var(--ink-muted);
+  transition: color 0.15s var(--ease), transform 0.12s var(--ease);
   font-family: var(--font-ui);
   font-size: 12.5px;
   cursor: pointer;
 }
 .advanced-toggle:hover { color: var(--ink); }
+.advanced-toggle:active { transform: scale(0.98); }
 .advanced-chevron { width: 15px; height: 15px; transition: transform 0.2s var(--ease); }
 .advanced.open .advanced-chevron { transform: rotate(90deg); }
 .advanced-panel {


### PR DESCRIPTION
## 背景（振り返り）
「選択/状態表示はスキル参照できていたか」を再点検したところ、redesign-existing-projects §Interactivity and States の **「No active/pressed feedback → add subtle scale(0.98)/translateY(1px) on press」** が、ボタン以外（プロファイル行・「いま使っている Claude」・icon-btn・各トグル）に**未適用**だった。先のフォーカス修正（青い既定リング撤去）と合わせ、states 章のルールを機械点検して埋める。

## 変更
- `profile-item` / `now-claude` / `sharing-summary` に `:active scale(0.99〜0.995)`
- `icon-btn` に `:active scale(0.92)`、`advanced-toggle` に `scale(0.98)`
- 各 transition に `transform 0.12s` を追加し押下/解放を滑らかに
- `prefers-reduced-motion` 下は既存の全体停止規則で無効化

## 検証
- ヘッドレスで press-and-hold 時の computed transform が `scale(0.99)` になることを実測。detail(内訳展開) の回帰なしを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)