### PR TITLE
fix(website): JAセクション見出しの折り返しを balance で統一

### DIFF
--- a/website/style.css
+++ b/website/style.css
@@ -278,8 +278,11 @@ html[lang="ja"] .subtext {
 @supports (text-wrap: balance) {
     .headline,
     .feature-intro h2,
+    .screens-header h2,
+    .usecases-header h2,
     .workflow-header h2,
     .guide-header h2,
+    .faq-header h2,
     .guide-card h3,
     .step-body h3 {
         text-wrap: balance;


### PR DESCRIPTION
screens/usecases/faq の各セクション見出しにも text-wrap balance を適用し、全 JA 見出しの折り返しを均一化。直前PR(#63)では6見出しに留めていた balance 化を全セクションへ拡張する一貫性修正。

このPRはクリーンなコミットメッセージ(コード片・引用符なし)で、release-please のパース失敗(#63が unexpected token で取りこぼされた件)を回避し v0.8.2 を起票させる役割も兼ねる。