### PR TITLE
docs(website,readme): Rust/Tauri 選定理由の技術メモを LP と README に追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ crates/
   desktop/   # Tauri v2 menu bar app and settings UI
 ```
 
+## Why Rust and Tauri
+
+CSW is built around a shared Rust library (`crates/core`) that handles environment isolation, path resolution, and data safety; the CLI (`csw`) and the menu-bar GUI are thin layers over that same core. Because the top priority is never destroying your existing Claude data, the core lives in Rust, where invariants are enforced at compile time.
+
+The GUI uses Tauri v2, which renders through the operating system's WebView (WebKit on macOS) instead of bundling a browser engine. The result is a small download (the universal DMG is around 7 MB), and code signing plus notarization run through Tauri's standard distribution flow.
+
+This also keeps the development and verification loop easy to automate: the core is checked continuously by the Rust compiler, clippy, and tests, and the UI can be rendered and inspected with a standard headless browser in CI.
+
+For native macOS UI, Apple's Swift and SwiftUI are the first choice, and an excellent one for apps that need deep system integration or a richly crafted native experience. Because CSW's value centers on systems-level logic with a thin UI, we prioritized core correctness and an automatable verification loop. A different kind of app would call for a different choice.
+
 ## License
 
 MIT
@@ -181,3 +191,13 @@ crates/
   cli/       # CLIツール (csw コマンド)
   desktop/   # Tauri v2 を用いたメニューバーアプリと設定画面
 ```
+
+### なぜ Rust と Tauri なのか
+
+CSW の中核は、環境の隔離・パス解決・データ保護を担う共有の Rust ライブラリ（`crates/core`）です。CLI（`csw`）とメニューバー GUI は、どちらもこの同じコアの上に薄く乗っています。ユーザーの既存 Claude データを壊さないことが最優先のため、不変条件をコンパイル時に固められる Rust を中核に置いています。
+
+GUI は Tauri v2 で、macOS 標準の WebView（WebKit）を使い、ブラウザエンジンを同梱しません。そのため配布物は小さく（universal の DMG で約 7MB）、署名と公証も Tauri の標準的な配布フローでそのまま行えます。
+
+この構成は、開発と検証のループを自動で回しやすい利点もあります。中核は Rust のコンパイラ・clippy・テストで継続的に検証でき、画面は標準的なヘッドレスブラウザで CI 上でもレンダリング確認できます。
+
+macOS ネイティブ UI の第一候補は Apple の Swift と SwiftUI で、深いシステム統合や作り込んだネイティブ体験が必要なアプリには優れた選択肢です。CSW は価値の中心がシステム寄りのロジックにあり UI が薄いため、コアの正しさと自動で回る検証を優先しました。用途が変われば、最適な選択も変わります。

--- a/website/index.html
+++ b/website/index.html
@@ -238,6 +238,20 @@
                 </div>
             </div>
         </section>
+
+        <!-- Engineering note -->
+        <section id="tech-note" class="tech-note container fade-in">
+            <div class="faq-header">
+                <h2>Engineering note: why Rust and Tauri</h2>
+                <p>CSW is built around a Rust library shared by both the CLI and the GUI. Here is the reasoning behind that choice, from a development and verification standpoint.</p>
+            </div>
+            <div class="tech-note-body">
+                <p>At the core of CSW is a shared Rust library that handles environment isolation, path resolution, and data safety. The command line (<code>csw</code>) and the menu-bar GUI are both thin layers over this same core. Because not destroying your existing data is the top priority, we chose Rust at the center, where invariants can be enforced at compile time.</p>
+                <p>The GUI is built with Tauri v2. Tauri renders through the operating system's WebView (WebKit on macOS) instead of bundling a browser engine, so the download stays small: the universal DMG is around 7 MB. Code signing and notarization are handled through Tauri's standard distribution flow.</p>
+                <p>This setup also keeps the development and verification loop easy to automate. The core logic is continuously checked by the Rust compiler, clippy, and tests, and the interface can be rendered and inspected with a standard headless browser. We prioritized a verification loop that runs mechanically in CI.</p>
+                <p>For native macOS UI, Apple's Swift and SwiftUI are the first choice, and an excellent one for apps that need deep system integration or a richly crafted native experience. Because CSW's value centers on systems-level logic with a thin UI, we prioritized core correctness and automated verification by choosing Rust and Tauri. A different kind of app would call for a different choice.</p>
+            </div>
+        </section>
     </main>
 
     <footer class="site-footer container">

--- a/website/ja/index.html
+++ b/website/ja/index.html
@@ -238,6 +238,20 @@
                 </div>
             </div>
         </section>
+
+        <!-- 技術メモ -->
+        <section id="tech-note" class="tech-note container fade-in">
+            <div class="faq-header">
+                <h2>技術メモ: なぜ Rust と Tauri なのか</h2>
+                <p>CSW の核は、CLI と GUI が共用する Rust のライブラリです。設計の理由を、開発と検証の観点から残しておきます。</p>
+            </div>
+            <div class="tech-note-body">
+                <p>CSW の中核は、環境の隔離・パス解決・データ保護を担う共有の Rust ライブラリです。コマンドライン（<code>csw</code>）とメニューバー GUI は、どちらもこの同じコアの上に薄く乗っています。ユーザーの既存データを壊さないことが最優先のツールなので、不変条件をコンパイル時に固められる Rust を中核に選びました。</p>
+                <p>GUI は Tauri v2 で作っています。Tauri は macOS 標準の WebView（WebKit）を使い、ブラウザエンジンを同梱しません。そのため配布物は小さく、universal の DMG で約 7MB に収まります。コードの署名と公証も、Tauri の標準的な配布フローでそのまま行えます。</p>
+                <p>この構成は、開発と検証のループを自動で回しやすいという利点もあります。中核のロジックは Rust のコンパイラ・clippy・テストで継続的に検証でき、画面は標準的なヘッドレスブラウザで実際にレンダリングして確認できます。CI 上で機械的に回る検証の土台を重視しました。</p>
+                <p>macOS ネイティブ UI の第一候補は Apple の Swift と SwiftUI で、深いシステム統合や作り込んだネイティブ体験が必要なアプリには優れた選択肢です。CSW は価値の中心がシステム寄りのロジックにあり UI が薄いため、コアの正しさと自動検証を優先して Rust と Tauri を選びました。用途が変われば、最適な選択も変わります。</p>
+            </div>
+        </section>
     </main>
 
     <footer class="site-footer container">

--- a/website/style.css
+++ b/website/style.css
@@ -768,6 +768,26 @@ html[lang="ja"] .faq-header h2 {
     font-size: 1.0625rem;
 }
 
+/* Engineering note (technical column near the foot of the page) */
+.tech-note {
+    padding-bottom: 120px;
+}
+.tech-note-body {
+    max-width: 760px;
+}
+.tech-note-body p {
+    color: var(--text-secondary);
+    font-size: 1.0625rem; /* body-lg — 17px */
+    line-height: 1.8;
+    margin-bottom: 16px;
+}
+.tech-note-body p:last-child {
+    margin-bottom: 0;
+}
+html[lang="ja"] .tech-note-body p {
+    line-height: 1.9;
+}
+
 /* Footer */
 .site-footer {
     border-top: 1px solid rgba(255, 255, 255, 0.08);


### PR DESCRIPTION
## 概要
LP と README の末尾に、CSW が Rust + Tauri を選んだ理由を「開発のしやすさ + 検証ループのしやすさ」の観点で書いた技術メモを追加。Swift/SwiftUI を貶めず、ネイティブの第一候補として敬意を持って併記。

## 内容(ja/en 両方)
- 共有 Rust コア(crates/core)を CLI と GUI が共用。データを壊さないことが最優先のため核を Rust に。
- GUI は Tauri v2。OS 標準 WebView(WebKit)でブラウザエンジン非同梱 → 小さい配布物(universal DMG 約7MB)。署名・公証は標準フロー。
- Rust のコンパイラ/clippy/テスト + ヘッドレスブラウザで、検証ループを CI で自動化しやすい。
- ネイティブ UI の第一候補は Swift/SwiftUI。CSW は UI が薄くロジックが核なので Rust/Tauri を選択。用途が変われば選択も変わる。

## 裏取り(雰囲気で書かない)
- Tauri 公式: [Process Model](https://v2.tauri.app/concept/process-model/)(OS の WebView を使い最終バイナリは小さい) / [macOS Code Signing](https://v2.tauri.app/distribute/sign/macos/)(署名+公証対応)。
- CSW 実測: Tauri 2.11.3、universal DMG 6,997,851 バイト(約6.7MiB)、crates/core を CLI/GUI 共用。

## 検証
ja/en・desktop/mobile をヘッドレス実描画で確認(横溢れなし・可読)。禁止記号(※/＊/em-dash/絵文字)なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)