### PR TITLE
docs(website): カスタムCLAUDE_CONFIG_DIR利用時の挙動をFAQに追記

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -221,6 +221,10 @@
                     <p class="faq-a">Your existing Claude Desktop and Claude Code setup. CSW only uses it as the reference point and never changes or deletes your settings, history, or login.</p>
                 </div>
                 <div class="faq-item">
+                    <p class="faq-q">Does it work if I've customized where my existing config lives?</p>
+                    <p class="faq-a">The desktop app uses the standard location (<code>~/Library/Application Support/Claude</code>) as is. Only for Claude Code (CLI): if you've moved its config away from the default <code>~/.claude</code> with the <code>CLAUDE_CONFIG_DIR</code> environment variable, the CLI side of "Existing Claude" won't automatically point at that custom location (because CSW assumes the standard one). Your existing <code>CLAUDE_CONFIG_DIR</code> setup keeps working as before, and CSW never rewrites it.</p>
+                </div>
+                <div class="faq-item">
                     <p class="faq-q">Do I need a new environment just to use the same account?</p>
                     <p class="faq-a">No. If you only want to keep using the same setup, just launch Claude as usual and "Existing Claude" is used directly. CSW helps when you want independent environments for other accounts or projects.</p>
                 </div>

--- a/website/ja/index.html
+++ b/website/ja/index.html
@@ -221,6 +221,10 @@
                     <p class="faq-a">普段お使いの既存の Claudeデスクトップアプリと Claude Code の環境です。CSW はこれを基準にするだけで、設定・履歴・ログインを変更も削除もしません。</p>
                 </div>
                 <div class="faq-item">
+                    <p class="faq-q">既存の設定を別の場所にカスタマイズしていても使えますか？</p>
+                    <p class="faq-a">デスクトップアプリは標準の場所（<code>~/Library/Application Support/Claude</code>）をそのまま扱います。Claude Code（CLI）の設定だけは、環境変数 <code>CLAUDE_CONFIG_DIR</code> を使って標準の <code>~/.claude</code> から別の場所へ移している場合、「既存の Claude」の CLI 側はその独自の場所を自動では指しません（CSW が標準の場所を前提にしているためです）。その場合もこれまでの <code>CLAUDE_CONFIG_DIR</code> 運用はそのまま使え、CSW が勝手に書き換えることはありません。</p>
+                </div>
+                <div class="faq-item">
                     <p class="faq-q">同じアカウントでも環境を作る必要がありますか？</p>
                     <p class="faq-a">いいえ。同じ環境を使い続けたいだけなら不要です。いつもどおり起動すれば「既存の Claude」が使われます。CSW は別アカウントや別案件の独立環境を増やすときに役立ちます。</p>
                 </div>


### PR DESCRIPTION
Claude Code の設定を CLAUDE_CONFIG_DIR で標準の ~/.claude から移している場合、「既存の Claude」の CLI 側はその独自の場所を自動では指さない(CSW は標準の場所を前提)挙動を ja/en の FAQ に明記。デスクトップ側は標準の場所をそのまま扱い、既存の CLAUDE_CONFIG_DIR 運用も書き換えない旨も記載。自動追従は GUI が export 環境変数を継承しない等で確実な検出が難しいため、まず挙動の明記を選択。docs のみ=リリース対象外(core_commit_standard §1.1)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)