### PR TITLE
chore(preview): LPを Claude の launch 機能でプレビューできるよう launch.json を追加

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "lp",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "http.server", "8181", "--directory", "website"],
+      "port": 8181
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ cargo fmt --all                    # フォーマット
 
 GUI の実機確認は `cargo tauri dev` (要 `cargo install tauri-cli`)。デスクトップ署名/公証/DMG は GitHub Actions の `Release Please` ワークフローが担う。
 
+LP (`website/`) のプレビューは Claude の launch 機能で `.claude/launch.json` の `lp` を起動する (preview_start で `website/` を `python3 -m http.server` 配信、EN は `/`、日本語は `/ja/`)。`website/` をルートに配信しないと相対パス (`../style.css` 等) が解決しないので、単体 HTML を file:// で開くのではなくこの設定で見る。
+
 ## Skill トリガーテーブル
 
 以下の条件に合致したら、該当する `.agents/skills/<name>/SKILL.md` を `Read` で読み、その手順に従う。`/bugfix` `/spec-first` `/audit-consistency` はスラッシュコマンドからも起動できる (`.claude/commands/`)。


### PR DESCRIPTION
## 概要
`.claude/launch.json` に `lp` 設定を追加し、Claude の launch/preview 機能(`preview_start`)で LP を配信できるようにした。

## 内容
- `website/` を `python3 -m http.server`(ゼロ依存)で配信する `lp` 設定。EN は `/`、日本語は `/ja/`。
- `website/` をルートに配信しないと ja の相対パス(`../style.css` 等)が解決しないため、単体 HTML の file:// でなくこの設定で見る旨を CLAUDE.md に追記。
- 配信は実テスト済み(index.html / ja/index.html / style.css / assets / script.js すべて 200)。

`.claude` 設定のみ=リリース対象外(core_commit_standard §1.1)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)