### PR TITLE
fix(desktop): 環境作成のIME Enter誤作成を防ぎ作成前に確認ステップを追加

### DIFF
--- a/crates/desktop/ui/index.html
+++ b/crates/desktop/ui/index.html
@@ -217,10 +217,7 @@
           </div>
           <div class="view-fade" id="createFade" hidden></div>
         </div>
-        <div class="view-footer">
-          <button type="button" class="btn btn-ghost" id="btnCreateCancel">やめる</button>
-          <button type="button" class="btn btn-primary" id="btnCreateSubmit">この環境を作る</button>
-        </div>
+        <div class="view-footer" id="createFooter"></div>
       </section>
     </main>
   </div>

--- a/crates/desktop/ui/main.js
+++ b/crates/desktop/ui/main.js
@@ -155,8 +155,7 @@ const el = {
   advancedState: $('advancedState'),
   advancedReset: $('advancedReset'),
   advancedGroups: $('advancedGroups'),
-  btnCreateCancel: $('btnCreateCancel'),
-  btnCreateSubmit: $('btnCreateSubmit'),
+  createFooter: $('createFooter'),
   emptyScroll: $('emptyScroll'),
   emptyFade: $('emptyFade'),
   detailScroll: $('detailScroll'),
@@ -518,9 +517,36 @@ function showCreate() {
   el.nameError.hidden = true;
   setMode('isolate');
   closeAdvanced();
+  renderCreateFooter();
   setView('create');
   applyRootsStatus();
   setTimeout(() => el.inputName.focus(), 0);
+}
+
+// --- Create-view footer: deliberate two-step (review → confirm) -------------
+// A stray Enter (e.g. confirming a Japanese IME kanji conversion) must never
+// create an environment, so creating always goes through an explicit confirm step.
+function cancelCreate() {
+  withTransition(() => (selectedName ? showDetail(selectedName) : showEmpty()));
+}
+function renderCreateFooter() {
+  el.createFooter.className = 'view-footer';
+  el.createFooter.replaceChildren(
+    h('button', { type: 'button', class: 'btn btn-ghost', onclick: cancelCreate }, 'やめる'),
+    h('button', { type: 'button', class: 'btn btn-primary', onclick: requestCreate }, 'この環境を作る'));
+}
+// Validate the name, then ask for an explicit confirmation before creating.
+function requestCreate() {
+  const name = el.inputName.value.trim();
+  const err = validateName(name);
+  if (err) { el.nameError.textContent = err; el.nameError.hidden = false; el.inputName.focus(); return; }
+  el.nameError.hidden = true;
+  el.createFooter.className = 'view-footer split';
+  el.createFooter.replaceChildren(
+    h('span', { class: 'confirm-text', text: `「${name}」を作成します。` }),
+    h('div', { class: 'footer-group' },
+      h('button', { type: 'button', class: 'btn btn-ghost', onclick: renderCreateFooter }, '戻る'),
+      h('button', { type: 'button', class: 'btn btn-primary', onclick: submitCreate }, '作成する')));
 }
 
 // Gate the "share" mode by what the existing Claude actually has at the standard
@@ -633,7 +659,8 @@ async function submitCreate() {
   const args = { name, mode: currentMode, icon: iconVal || null };
   if (advancedCustomized) args.sharingOverrides = { ...overrides };
 
-  el.btnCreateSubmit.disabled = true;
+  const confirmBtn = el.createFooter.querySelector('.btn-primary');
+  if (confirmBtn) confirmBtn.disabled = true;
   try {
     await invoke('create_profile', args);
     localStorage.setItem('csw_onboarded', '1');
@@ -643,8 +670,7 @@ async function submitCreate() {
     showToast(`${name}を作成しました`);
   } catch (e) {
     showToast('作成できませんでした。同じ名前がすでにあるか確認してください。', true);
-  } finally {
-    el.btnCreateSubmit.disabled = false;
+    renderCreateFooter(); // restore the form footer so the user can fix and retry
   }
 }
 
@@ -685,9 +711,6 @@ async function refreshProfiles() {
 function wireEvents() {
   el.btnCreate.addEventListener('click', () => withTransition(showCreate));
   el.btnCreateEmpty.addEventListener('click', () => withTransition(showCreate));
-  el.btnCreateCancel.addEventListener('click', () => withTransition(() =>
-    selectedName ? showDetail(selectedName) : showEmpty()));
-  el.btnCreateSubmit.addEventListener('click', submitCreate);
 
   document.querySelectorAll('input[name="mode"]').forEach((r) =>
     r.addEventListener('change', () => {
@@ -712,7 +735,11 @@ function wireEvents() {
   el.detailScroll.addEventListener('scroll', () => fadeFor(el.detailScroll, el.detailFade), { passive: true });
   el.createScroll.addEventListener('scroll', () => fadeFor(el.createScroll, el.createFade), { passive: true });
   window.addEventListener('resize', refreshFades);
-  el.inputName.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitCreate(); });
+  el.inputName.addEventListener('keydown', (e) => {
+    // Ignore Enter while an IME composition is active (e.g. confirming a Japanese
+    // kanji conversion) so it never creates; otherwise go to the confirmation step.
+    if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229) { e.preventDefault(); requestCreate(); }
+  });
   el.inputIcon.addEventListener('input', () => { // typing an emoji overrides a glyph; clearing resets
     createIcon = el.inputIcon.value.trim();
     syncIconPicker();


### PR DESCRIPTION
## 不具合
名前入力で日本語(IME)の漢字変換を確定する Enter が、そのまま環境作成を発火させて誤作成していた。前画面に戻る導線も分かりにくく、作成前の確認も無かった。

## 修正
- **IME**: Enter ハンドラを composition 中(e.isComposing / keyCode 229)は無視。確定後の Enter も即作成でなく確認ステップへ。
- **確認**: 「この環境を作る」/Enter → 名前検証 → 「「<名前>」を作成します。」+[戻る][作成する]の確認を表示してから作成。
- **戻り導線**: 作成画面フッターを削除確認と同じ流儀で JS 管理化。[やめる]=前画面、確認の[戻る]=フォーム。

## 検証
ヘッドレスで通常フッター/確認ステップを実描画目視。JS 構文OK。非破壊なので確認は軽い1段。既存スクショ(通常フッター)は見た目不変で再生成不要。crates/ 変更のため fix=リリース対象。

🤖 Generated with [Claude Code](https://claude.com/claude-code)