### PR TITLE
docs(website): LPにfaviconを追加

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Claude Desktop Switcher</title>
     <meta name="description" content="Safely manage and switch between multiple Claude Desktop accounts with zero impact on your existing setup.">
+    <link rel="icon" type="image/png" href="assets/logo.png">
+    <link rel="apple-touch-icon" href="assets/logo.png">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/website/ja/index.html
+++ b/website/ja/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Claude Desktop Switcher</title>
     <meta name="description" content="既存の環境を一切壊さず、複数のClaude Desktopアカウントを安全に管理・切り替え。">
+    <link rel="icon" type="image/png" href="../assets/logo.png">
+    <link rel="apple-touch-icon" href="../assets/logo.png">
     <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
ブラウザのタブにアイコンが出ない指摘を受け、既存の CSW マーク `assets/logo.png`(146x146 透過PNG)を favicon と apple-touch-icon に設定。ja/en 両方の head に追加。website のみ=リリース対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)