### PR TITLE
docs(website): ヘッダーに重要セクションのリンクを追加しアンカー着地を修正、DLボタンの矢印を削除

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -21,7 +21,9 @@
             </div>
             <nav class="nav-links">
                 <a href="#features">Features</a>
-                <a href="#how-it-works">How it Works</a>
+                <a href="#screens">Screens</a>
+                <a href="#how-it-works">How it works</a>
+                <a href="#faq">FAQ</a>
                 <div class="lang-toggle">
                     <span class="active-lang">EN</span> / <a href="ja/index.html">JA</a>
                 </div>
@@ -38,7 +40,7 @@
                 <h1 class="headline">Separate your Claude Desktop App by use case.</h1>
                 <p class="subtext">Keep chat, Projects, Claude Cowork, Artifacts, and Claude Design apart by account and use case, with Claude Code linked when you want it. A macOS utility for the whole Claude Desktop App suite.</p>
                 <div class="button-group">
-                    <a href="https://github.com/matsumotory/claude-desktop-switcher/releases/latest" class="btn btn-primary">Download for macOS (.dmg) <div class="btn-icon-wrap">↗</div></a>
+                    <a href="https://github.com/matsumotory/claude-desktop-switcher/releases/latest" class="btn btn-primary">Download for macOS (.dmg)</a>
                     <a href="https://github.com/matsumotory/claude-desktop-switcher/blob/main/docs/USER_GUIDE_EN.md" class="btn btn-secondary">Read Documentation</a>
                 </div>
             </div>

--- a/website/ja/index.html
+++ b/website/ja/index.html
@@ -21,7 +21,9 @@
             </div>
             <nav class="nav-links">
                 <a href="#features">特徴</a>
+                <a href="#screens">画面</a>
                 <a href="#how-it-works">使い方</a>
+                <a href="#faq">よくある質問</a>
                 <div class="lang-toggle">
                     <a href="../index.html">EN</a> / <span class="active-lang">JA</span>
                 </div>
@@ -38,7 +40,7 @@
                 <h1 class="headline">Claudeデスクトップアプリを<wbr>用途ごとに分ける。</h1>
                 <p class="subtext">チャット・Projects・Claude Cowork・Artifacts・Claude Design を含むスイート全体を、アカウント・用途ごとに分離。必要なら Claude Code（CLI）も連動できる Mac 用ユーティリティです。</p>
                 <div class="button-group">
-                    <a href="https://github.com/matsumotory/claude-desktop-switcher/releases/latest" class="btn btn-primary">macOS版をダウンロード (.dmg) <div class="btn-icon-wrap">↗</div></a>
+                    <a href="https://github.com/matsumotory/claude-desktop-switcher/releases/latest" class="btn btn-primary">macOS版をダウンロード (.dmg)</a>
                     <a href="https://github.com/matsumotory/claude-desktop-switcher/blob/main/docs/USER_GUIDE.md" class="btn btn-secondary">ドキュメントを読む</a>
                 </div>
             </div>

--- a/website/style.css
+++ b/website/style.css
@@ -28,6 +28,12 @@ body {
     overflow-x: hidden;
 }
 
+/* The header is sticky (~73px); offset in-page anchor jumps so a section's heading
+   lands below the header instead of hidden behind it. */
+html {
+    scroll-padding-top: 88px;
+}
+
 html[lang="ja"] body {
     font-family: 'Outfit', 'Helvetica Neue', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', 'Noto Sans JP', Meiryo, sans-serif;
     line-height: 1.8;


### PR DESCRIPTION
## 内容
- ヘッダーナビに #screens(画面)/#faq(よくある質問)を追加(特徴/画面/使い方/よくある質問)。モバイルは従来どおり in-page リンク非表示で崩れない。
- アンカー着地ずれ修正: sticky ヘッダー(73px)で見出しが隠れていた → html に `scroll-padding-top:88px` を追加し見出しがヘッダー直下に出るように。
- ダウンロードボタンの素の「↗」を削除(ラベルが明示・副ボタンと不整合・外部遷移の意で download と別=冗長)。ja/en。

## 検証
ヘッドレスで desktop ナビ(4リンク)・矢印削除・#faq 着地(top=87px, header=73px)を確認。website のみ=リリース対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)