### PR TITLE
docs(website): モバイルのセクションナビをハンバーガーメニュー化する

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -38,7 +38,11 @@
                 <img src="assets/logo.png" alt="CSW Logo" style="width: 20px; height: 20px; object-fit: contain;">
                 <span class="logo-text">Claude Desktop Switcher</span>
             </div>
-            <nav class="nav-links">
+            <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="site-nav">
+                <span class="nav-toggle-bar"></span>
+                <span class="nav-toggle-bar"></span>
+            </button>
+            <nav class="nav-links" id="site-nav">
                 <a href="#features">Features</a>
                 <a href="#screens">Screens</a>
                 <a href="#how-it-works">How it works</a>

--- a/website/ja/index.html
+++ b/website/ja/index.html
@@ -38,7 +38,11 @@
                 <img src="../assets/logo.png" alt="CSW Logo" style="width: 20px; height: 20px; object-fit: contain;">
                 <span class="logo-text">Claude Desktop Switcher</span>
             </div>
-            <nav class="nav-links">
+            <button class="nav-toggle" type="button" aria-label="メニュー" aria-expanded="false" aria-controls="site-nav">
+                <span class="nav-toggle-bar"></span>
+                <span class="nav-toggle-bar"></span>
+            </button>
+            <nav class="nav-links" id="site-nav">
                 <a href="#features">特徴</a>
                 <a href="#screens">画面</a>
                 <a href="#how-it-works">使い方</a>

--- a/website/script.js
+++ b/website/script.js
@@ -19,4 +19,33 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const fadeElements = document.querySelectorAll('.fade-in');
     fadeElements.forEach(el => observer.observe(el));
+
+    // Mobile nav: hamburger toggle (opens the glass panel under 768px)
+    const navToggle = document.querySelector('.nav-toggle');
+    const navLinks = document.querySelector('.nav-links');
+    if (navToggle && navLinks) {
+        const setNav = (open) => {
+            document.body.classList.toggle('nav-open', open);
+            navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+        };
+        navToggle.addEventListener('click', (e) => {
+            e.stopPropagation();
+            setNav(!document.body.classList.contains('nav-open'));
+        });
+        navLinks.querySelectorAll('a').forEach((a) => {
+            a.addEventListener('click', () => setNav(false));
+        });
+        document.addEventListener('click', (e) => {
+            if (document.body.classList.contains('nav-open') &&
+                !navLinks.contains(e.target) && !navToggle.contains(e.target)) {
+                setNav(false);
+            }
+        });
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') setNav(false);
+        });
+        window.addEventListener('resize', () => {
+            if (window.innerWidth > 768) setNav(false);
+        });
+    }
 });

--- a/website/style.css
+++ b/website/style.css
@@ -97,6 +97,42 @@ html[lang="ja"] body {
     color: var(--text-primary);
 }
 
+/* Mobile nav toggle (hamburger) — hidden on desktop, shown under 768px. */
+.nav-toggle {
+    display: none;
+    position: relative;
+    width: 40px;
+    height: 40px;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    z-index: 61;
+}
+.nav-toggle-bar {
+    position: absolute;
+    left: 9px;
+    right: 9px;
+    height: 1.5px;
+    background: var(--text-primary);
+    border-radius: 2px;
+    transition: transform 0.4s var(--spring-easing), opacity 0.25s ease;
+}
+.nav-toggle-bar:nth-child(1) { top: 15px; }
+.nav-toggle-bar:nth-child(2) { top: 23px; }
+body.nav-open .nav-toggle-bar:nth-child(1) { transform: translateY(4px) rotate(45deg); }
+body.nav-open .nav-toggle-bar:nth-child(2) { transform: translateY(-4px) rotate(-45deg); }
+
+@media (prefers-reduced-motion: reduce) {
+    .nav-toggle-bar,
+    .nav-links,
+    .nav-links > * {
+        transition-duration: 0.001s;
+    }
+}
+
 .lang-toggle {
     display: inline-flex;
     align-items: center;
@@ -962,13 +998,79 @@ html[lang="ja"] .terms-item p {
         padding-right: 20px;
     }
 
-    /* Header: there is no room for in-page anchors without a menu, so drop
-       them on mobile and keep the language toggle + GitHub action. */
+    /* Header on mobile: collapse the nav into a hamburger-triggered glass
+       panel so the in-page section links stay reachable
+       (design-taste-frontend nav guidance / high-end-visual-design 5.A). */
+    .nav-toggle {
+        display: block;
+    }
     .nav-links {
-        gap: 16px;
+        position: absolute;
+        top: calc(100% + 10px);
+        right: 16px;
+        left: 16px;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 2px;
+        padding: 10px;
+        background: rgba(10, 10, 10, 0.92);
+        -webkit-backdrop-filter: blur(22px);
+        backdrop-filter: blur(22px);
+        border: 1px solid var(--border-color);
+        border-radius: 18px;
+        box-shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
+        opacity: 0;
+        visibility: hidden;
+        transform: translateY(-8px) scale(0.985);
+        transform-origin: top right;
+        pointer-events: none;
+        transition: opacity 0.28s ease, transform 0.4s var(--spring-easing), visibility 0.28s;
+        z-index: 60;
+    }
+    body.nav-open .nav-links {
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(0) scale(1);
+        pointer-events: auto;
+    }
+    .nav-links > * {
+        opacity: 0;
+        transform: translateY(8px);
+        transition: opacity 0.35s ease, transform 0.4s var(--spring-easing), background-color 0.2s ease;
+    }
+    body.nav-open .nav-links > * {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    body.nav-open .nav-links > :nth-child(1) { transition-delay: 0.04s; }
+    body.nav-open .nav-links > :nth-child(2) { transition-delay: 0.08s; }
+    body.nav-open .nav-links > :nth-child(3) { transition-delay: 0.12s; }
+    body.nav-open .nav-links > :nth-child(4) { transition-delay: 0.16s; }
+    body.nav-open .nav-links > :nth-child(5) { transition-delay: 0.20s; }
+    body.nav-open .nav-links > :nth-child(6) { transition-delay: 0.24s; }
+    .nav-links > a:not(.btn),
+    .nav-links > .lang-toggle {
+        padding: 12px 14px;
+        border-radius: 11px;
+        font-size: 1rem;
     }
     .nav-links a[href^="#"] {
-        display: none;
+        display: block;
+        color: var(--text-primary);
+    }
+    .nav-links a:not(.btn):hover,
+    .nav-links a:not(.btn):active {
+        background: var(--bg-surface-hover);
+        color: var(--text-primary);
+    }
+    .nav-links .lang-toggle {
+        justify-content: flex-start;
+        color: var(--text-secondary);
+    }
+    .nav-links .btn-ghost {
+        width: 100%;
+        justify-content: center;
+        margin-top: 4px;
     }
     .logo-text {
         font-size: 0.95rem;


### PR DESCRIPTION
## 背景
LP のヘッダーのセクションリンク(特徴/画面/使い方/よくある質問)は、768px 以下で `display:none` にしており、モバイルではページ内ナビに到達できなかった。

## 対応
ハンバーガーメニューを追加(`design-taste-frontend` のナビ指針 / `high-end-visual-design` 5.A)。
- ハンバーガーをタップすると、グラスのドロップダウンにセクションリンク・言語切替・GitHub を段階表示。
- アイコンは X にモーフ。リンク/外側タップ/Esc/デスクトップ幅への復帰で閉じる。
- `aria-expanded` を同期。`prefers-reduced-motion` でアニメーション抑制。
- デスクトップの並びは不変。日英の LP と共有の `script.js`/`style.css` に適用。

## 検証(CDP・真のモバイル幅 setDeviceMetricsOverride)
- モバイル(390px): トグル表示、開くと 6 項目すべて可視(panel opacity 1/visible)、X モーフ、aria=true。EN/JA とも確認。
- デスクトップ(1280px): トグル `display:none`、セクションリンク 4 本インライン表示で回帰なし。

website のみの変更のためリリースは切らない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)