### PR TITLE
docs(website): アンカー着地のヘッダー被りと画像CLSを直す

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -80,7 +80,7 @@
                             <img src="assets/logo.png" class="menu-bar-logo" alt="CSW Icon">
                         </div>
                     </div>
-                    <img src="assets/hero.png?v=0.13.1" alt="Settings Interface" class="hero-image">
+                    <img src="assets/hero.png?v=0.13.1" width="1520" height="984" alt="Settings Interface" class="hero-image">
                 </div>
             </div>
         </section>
@@ -119,15 +119,15 @@
             </div>
             <div class="screens-bento">
                 <figure class="screen-card screen-wide fade-in delay-1">
-                    <img src="assets/screen_overview.png?v=0.13.1" alt="CSW settings window showing an environment's paths and a per-component carry-over matrix" loading="lazy">
+                    <img src="assets/screen_overview.png?v=0.13.1" width="1520" height="2224" alt="CSW settings window showing an environment's paths and a per-component carry-over matrix" loading="lazy">
                     <figcaption>Every environment gets its own data directories. For each component you decide whether it carries over from your existing setup or stays separate to this environment: common rules (CLAUDE.md), tool permissions and hooks (settings.json), plugins, skills, project conversations and memory (projects/), prompt history, and more. The account sign-in info (config.json) is always separate.</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
-                    <img src="assets/screen_create.png?v=0.13.1" alt="New-environment screen offering the three separation modes" loading="lazy">
+                    <img src="assets/screen_create.png?v=0.13.1" width="1520" height="2104" alt="New-environment screen offering the three separation modes" loading="lazy">
                     <figcaption>Create an environment in seconds. Choose how much carries over: separate the account only, separate conversations and memory too, or separate everything.</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
-                    <img src="assets/screen_onboarding.png?v=0.13.1" alt="First-run onboarding explaining that the existing setup is preserved" loading="lazy">
+                    <img src="assets/screen_onboarding.png?v=0.13.1" width="1520" height="1586" alt="First-run onboarding explaining that the existing setup is preserved" loading="lazy">
                     <figcaption>A short first-run tour. Your current environment is preserved as “Existing Claude” and never modified.</figcaption>
                 </figure>
             </div>

--- a/website/ja/index.html
+++ b/website/ja/index.html
@@ -80,7 +80,7 @@
                             <img src="../assets/logo.png" class="menu-bar-logo" alt="CSW Icon">
                         </div>
                     </div>
-                    <img src="../assets/ja_hero.png?v=0.13.1" alt="Settings Interface" class="hero-image">
+                    <img src="../assets/ja_hero.png?v=0.13.1" width="1520" height="996" alt="Settings Interface" class="hero-image">
                 </div>
             </div>
         </section>
@@ -119,15 +119,15 @@
             </div>
             <div class="screens-bento">
                 <figure class="screen-card screen-wide fade-in delay-1">
-                    <img src="../assets/ja_screen_overview.png?v=0.13.1" alt="各環境のパスと項目別の共有/分離マトリクスを表示した CSW 設定画面" loading="lazy">
+                    <img src="../assets/ja_screen_overview.png?v=0.13.1" width="1520" height="2198" alt="各環境のパスと項目別の共有/分離マトリクスを表示した CSW 設定画面" loading="lazy">
                     <figcaption>各環境は専用のデータディレクトリを持ちます。共有の中心は Claude Code 側の共通ルール（CLAUDE.md）・スキル・プラグインで、会話履歴・自動メモリ・入力履歴は項目ごとに引き継ぐか分けるかを選べます。アカウントのサインイン情報とコネクタ（MCP）設定は常に分離されます。</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
-                    <img src="../assets/ja_screen_create.png?v=0.13.1" alt="「アカウントだけ分ける」「会話とメモリも分ける」「すべて分ける」を選べる環境作成画面" loading="lazy">
+                    <img src="../assets/ja_screen_create.png?v=0.13.1" width="1520" height="1998" alt="「アカウントだけ分ける」「会話とメモリも分ける」「すべて分ける」を選べる環境作成画面" loading="lazy">
                     <figcaption>数秒で環境を作成。会話を続けつつ課金だけ分けるなら「アカウントだけ分ける」、設定だけ使い回すなら「会話とメモリも分ける」、何も引き継がないなら「すべて分ける」を選びます。どのモードでもアカウントは分かれます。</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
-                    <img src="../assets/ja_screen_onboarding.png?v=0.13.1" alt="既存環境が保持されることを説明する初回オンボーディング" loading="lazy">
+                    <img src="../assets/ja_screen_onboarding.png?v=0.13.1" width="1520" height="1586" alt="既存環境が保持されることを説明する初回オンボーディング" loading="lazy">
                     <figcaption>初回だけ表示される簡単な案内。現在の環境は「既存の Claude」として保持され、一切変更されません。</figcaption>
                 </figure>
             </div>

--- a/website/style.css
+++ b/website/style.css
@@ -28,10 +28,16 @@ body {
     overflow-x: hidden;
 }
 
-/* The header is sticky (~73px); offset in-page anchor jumps so a section's heading
-   lands below the header instead of hidden behind it. */
+/* The header is sticky (72px tall + 1px border). Offset in-page anchor jumps so a
+   section heading lands below it instead of behind it. scroll-margin-top on the
+   targets is the robust, scroll-container-independent mechanism; scroll-padding-top
+   on <html> is kept as a fallback. */
 html {
     scroll-padding-top: 88px;
+}
+
+section[id] {
+    scroll-margin-top: 88px;
 }
 
 html[lang="ja"] body {


### PR DESCRIPTION
## 何を直すか

モバイルでナビ/ハンバーガーのセクションリンクをタップすると、見出しが sticky ヘッダーの裏に潜ったり、タイミング次第で隠れたり成功したりしていた（flaky）。原因は2つで、両方を直す。

### 1. ヘッダー被り（決定的）
`body { overflow-x: hidden }` でスクロールコンテナが変わり、`html { scroll-padding-top }` が当てにならない。各アンカー先である `section[id]` に `scroll-margin-top: 88px` を付け、スクロールコンテナに依存しない形でヘッダー下に着地させる。`scroll-padding-top` はフォールバックとして残す。

### 2. 画像 CLS（flaky の主因）
スクショは `loading="lazy"` なのに `width`/`height` を持たず、ロード前は高さが詰まり、ロードで伸びる。アンカー先より上のスクショがジャンプ後にロードされると、ターゲットが最大 1416px ずれていた（キャッシュ/スクロール状況で発生が変わるため「たまに隠れる」）。hero とスクショ3枚に実寸の `width`/`height` を付け、ロード前に箱を予約して CLS を消す（`height: auto` でレスポンシブは維持）。EN/JA 両方に適用。

## 検証（CDP・390px モバイル・EN/JA）

| 項目 | 修正前 | 修正後 |
|---|---|---|
| 見出しの着地（ヘッダー下端=73px 基準） | #tech-note/#terms が −16〜−17px（隠れ） | 全アンカー +71〜+103px（可視） |
| 画像ロードによるターゲットずれ | 最大 1416px（EN #tech-note） | 0px（遅延画像が未ロードの瞬間でも一致） |
| クリック経路（フェードイン作動中・5アンカー×EN/JA） | — | immediate/settled とも 10/10 OK |
| 画像の歪み | — | attr比 == natural比（8/8） |
| 横スクロール | 390==390 | 390==390 |

`Emulation.setDeviceMetricsOverride`（真のモバイル幅）で計測。`--window-size` の 500px 床は使用していない。

## 既知の残留（据え置き）

フォントの `display=swap` により、初めての訪問で直リンク（例 `/#terms`）を新規タブで開いた初回ロードに限り、深いアンカーが最大 ~48px 上方向にずれうる。ページ内ナビのタップには影響せず、フォントキャッシュ後は解消する。軽微かつ範囲が狭いため今回は変更しない。

## リリースへの影響

`website/` のみの変更（`crates/` は不変）。`docs(website):` で積んでおり release-please のリリース PR は起票されない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
