### PR TITLE
docs(website): LP の screens を均等3カラムに、FAQ を単一カラムに整える

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -118,17 +118,17 @@
                 <p>The whole environment system lives in one settings window. Create an environment by choosing how much carries over, inspect exactly what each environment carries over, and switch from the menu bar.</p>
             </div>
             <div class="screens-bento">
-                <figure class="screen-card screen-wide fade-in delay-1">
+                <figure class="screen-card fade-in delay-1">
                     <img src="assets/screen_overview.png?v=0.13.1" width="1520" height="2224" alt="CSW settings window showing an environment's paths and a per-component carry-over matrix" loading="lazy">
-                    <figcaption>Every environment gets its own data directories. For each component you decide whether it carries over from your existing setup or stays separate to this environment: common rules (CLAUDE.md), tool permissions and hooks (settings.json), plugins, skills, project conversations and memory (projects/), prompt history, and more. The account sign-in info (config.json) is always separate.</figcaption>
+                    <figcaption>Every environment gets its own data directories. You choose per component what carries over and what stays separate; the account sign-in is always kept apart.</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
                     <img src="assets/screen_create.png?v=0.13.1" width="1520" height="2104" alt="New-environment screen offering the three separation modes" loading="lazy">
-                    <figcaption>Create an environment in seconds. Choose how much carries over: separate the account only, separate conversations and memory too, or separate everything.</figcaption>
+                    <figcaption>Create an environment in seconds. Choose how much carries over: the account only, conversations and memory too, or everything.</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
                     <img src="assets/screen_onboarding.png?v=0.13.2" width="1520" height="1658" alt="First-run onboarding explaining that the existing setup is preserved" loading="lazy">
-                    <figcaption>A short first-run tour. Your current environment is preserved as “Existing Claude” and never modified.</figcaption>
+                    <figcaption>A short first-run tour shown only the first time. Your current setup is preserved as “Existing Claude” and never modified.</figcaption>
                 </figure>
             </div>
         </section>

--- a/website/ja/index.html
+++ b/website/ja/index.html
@@ -118,17 +118,17 @@
                 <p>環境管理はすべて 1 つの設定ウインドウで完結します。分離・共有の環境を作り、各環境が何を共有しているかを確認し、メニューバーから切り替えられます。</p>
             </div>
             <div class="screens-bento">
-                <figure class="screen-card screen-wide fade-in delay-1">
+                <figure class="screen-card fade-in delay-1">
                     <img src="../assets/ja_screen_overview.png?v=0.13.1" width="1520" height="2198" alt="各環境のパスと項目別の共有/分離マトリクスを表示した CSW 設定画面" loading="lazy">
-                    <figcaption>各環境は専用のデータディレクトリを持ちます。共有の中心は Claude Code 側の共通ルール（CLAUDE.md）・スキル・プラグインで、会話履歴・自動メモリ・入力履歴は項目ごとに引き継ぐか分けるかを選べます。アカウントのサインイン情報とコネクタ（MCP）設定は常に分離されます。</figcaption>
+                    <figcaption>各環境は専用のデータディレクトリを持ちます。各項目を既存環境から引き継ぐか分けるかを選べ、アカウントのサインイン情報は常に分離されます。</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
                     <img src="../assets/ja_screen_create.png?v=0.13.1" width="1520" height="1998" alt="「アカウントだけ分ける」「会話とメモリも分ける」「すべて分ける」を選べる環境作成画面" loading="lazy">
-                    <figcaption>数秒で環境を作成。会話を続けつつ課金だけ分けるなら「アカウントだけ分ける」、設定だけ使い回すなら「会話とメモリも分ける」、何も引き継がないなら「すべて分ける」を選びます。どのモードでもアカウントは分かれます。</figcaption>
+                    <figcaption>環境は数秒で作成できます。アカウントだけ・会話とメモリも・すべて、の3つから引き継ぐ範囲を選びます。</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
                     <img src="../assets/ja_screen_onboarding.png?v=0.13.2" width="1520" height="1622" alt="既存環境が保持されることを説明する初回オンボーディング" loading="lazy">
-                    <figcaption>初回だけ表示される簡単な案内。現在の環境は「既存の Claude」として保持され、一切変更されません。</figcaption>
+                    <figcaption>初回だけ表示される短い案内です。現在の環境は「既存の Claude」として保持され、変更されることはありません。</figcaption>
                 </figure>
             </div>
         </section>

--- a/website/style.css
+++ b/website/style.css
@@ -804,20 +804,21 @@ html[lang="ja"] .faq-header h2 {
 }
 
 .faq-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0 64px;
-}
-
-@media (max-width: 900px) {
-    .faq-grid {
-        grid-template-columns: 1fr;
-    }
+    /* Single column. A 2-column grid coupled row heights, so a short answer next
+       to a long one left a big gap and the hairlines fell at different heights.
+       One column makes each item's height depend only on its own content, so the
+       separators are evenly spaced and the read order matches the DOM. Width is
+       capped (left-aligned under the header, matching the engineering notes). */
+    max-width: 820px;
 }
 
 .faq-item {
     padding: 28px 0;
     border-top: 1px solid var(--border-color);
+}
+.faq-item:first-child {
+    border-top: none;
+    padding-top: 0;
 }
 
 .faq-q {
@@ -832,6 +833,10 @@ html[lang="ja"] .faq-header h2 {
     color: var(--text-secondary);
     line-height: 1.7;
     font-size: 1.0625rem;
+}
+html[lang="ja"] .faq-a {
+    line-height: 1.8; /* JP body (japanese-typography-qa §3) */
+    overflow-wrap: anywhere; /* long URLs / paths never overflow */
 }
 
 /* Engineering notes: a few hairline-separated columns near the foot of the page.
@@ -1252,9 +1257,14 @@ html[lang="ja"] .screens-header h2 {
     line-height: 1.6;
 }
 .screens-bento {
+    /* Three equal portrait cards. The screenshots have different aspect ratios,
+       so align-items:start lets each card take its natural height instead of
+       stretching the shortest to match the tallest (which left a ragged gap
+       above its caption). No object-fit cropping: the full window stays visible. */
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(3, 1fr);
     gap: 24px;
+    align-items: start;
 }
 .screen-card {
     margin: 0;
@@ -1263,9 +1273,6 @@ html[lang="ja"] .screens-header h2 {
     overflow: hidden;
     background: var(--bg-surface);
     box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
-}
-.screen-card.screen-wide {
-    grid-column: 1 / -1;
 }
 .screen-card img {
     width: 100%;
@@ -1278,6 +1285,14 @@ html[lang="ja"] .screens-header h2 {
     font-size: 0.95rem;
     color: var(--text-secondary);
     line-height: 1.5;
+}
+html[lang="ja"] .screen-card figcaption {
+    line-height: 1.8; /* JP body breathes wider (japanese-typography-qa §3) */
+}
+@media (max-width: 1024px) {
+    .screens-bento {
+        grid-template-columns: repeat(2, 1fr);
+    }
 }
 @media (max-width: 768px) {
     .screens-bento {


### PR DESCRIPTION
## 概要
LP の「実際の画面」スクショセクションと「よくある質問(FAQ)」の、カード高さ・余白の不揃いと画像サイズを整えます（指摘: 1枚目の画像が大きすぎる／画像サイズ差で説明のマージンがバラバラ／FAQ の分量差で区切りがチグハグ）。

## screens（実際の画面）
- 1枚目 overview を全幅(`screen-wide`)で巨大表示していたのをやめ、**3枚を均等カラム**に。`align-items: start` で各カードを自然高にし、短い画像が引き伸ばされて figcaption 上に空白が出る現象を解消。
- **画像は切らない**（`object-fit:cover` の一律トリミングは検討したが、最も低い onboarding が左右で約14%サイドクロップされ内容が欠けるため不採用）。`width/height` 属性は残し CLS を予約。
- figcaption を**2文・丁寧語・分量を均一**に揃える（ja/en）。日本語は行間1.8。

## FAQ
- 2列 grid は行高が左右連動し、分量差でハーフラインの間隔が不揃いだった。**単一カラム（`max-width:820px`・左寄せ）**にして各項目の高さが自分の内容だけで決まるようにし、区切りを等間隔に。先頭項目は上線なし。

## 適用スキル
design-taste-frontend（§4.4 SHAPE LOCK / §4.7 bento・並列要素 / §4.9 リスト）、japanese-typography-qa（§5 並列コピーの分量・文体統一、§3 行間、§1 孤立）、メモリ balance-parallel-ui-content-and-register。SHAPE/THEME/COLOR ロックと既存スクショは不変。

## 検証（CDP 実寸）
desktop 1280 / 真のモバイル 390（DSF2）× ja/en で実レンダ実測:
- 横スクロールゼロ（全構成 `scrollWidth==innerWidth`）。
- screens 3カラム、overview の巨大化解消、figcaption は画像直下・分量均一（EN capH 123/100/100, JA 141/114/114）。
- FAQ 単一カラム左寄せ（grid 左端=見出し左端=64px）、ハーフライン等間隔。
- figcaption の JA 最終行 8–13字で孤立なし。

website のみのため `docs(website):`（release-please 非対象）。
