### PR TITLE
docs: リリース手順(release-please PRのマージ)をスキルに落とす

### DIFF
--- a/.agents/skills/core_pr_merge_checklist/SKILL.md
+++ b/.agents/skills/core_pr_merge_checklist/SKILL.md
@@ -137,3 +137,36 @@ PR の一部だけが有用な場合:
 2. PR にクローズ理由をコメントで明記する
 3. 取り込んだ変更 / 除外した変更を区別して記述する
 
+## リリース PR (release-please) のマージ
+
+`fix:` / `feat:` / 破壊的変更が main に入ると、release-please が `chore(main): release X.Y.Z` という PR を自動起票する。これは版更新 (`Cargo.toml` / `crates/desktop/tauri.conf.json` / `.release-please-manifest.json`) と `CHANGELOG.md` だけで、**コードは含まない** (機能は各 `feat`/`fix` PR で CI 済み)。
+
+> [!IMPORTANT]
+> **リリースはユーザーの明示指示 (「リリースして」等) があってから行う。** 公開・巻き戻し困難な操作なので、勝手に走らせない。
+
+### なぜ通常マージが BLOCKED になるか
+
+このリリース PR は GitHub の bot (`GITHUB_TOKEN`) が作るため、GitHub のループ防止で `pull_request` ワークフローが発火しない。結果、必須チェック (Build / Test / Lint / Secret scan) が一つも付かず、`mergeStateStatus` が `BLOCKED` になる (`mergeable` は `MERGEABLE` のまま)。
+
+### 正しい手順 (`--admin` を使わない)
+
+`main` の branch protection は `enforce_admins:false` なので `--admin` で押し込むことは可能だが、**使わない** (standing rule、auto モードの classifier もブロックする)。代わりに必須チェックを実際に走らせてから通常マージする:
+
+1. `git fetch origin release-please--branches--main`
+2. worktree を切り、release ブランチ (`release-please--branches--main`) に **空コミットを 1 つ** push する:
+   `git commit --allow-empty -m "chore: 必須チェックを発火させる"` → `git push origin HEAD:release-please--branches--main`
+   (CI ワークフローは `on: pull_request` で paths フィルタが無いため、実ユーザーの push が `synchronize` で必須チェックを発火させる。取りこぼした CHANGELOG エントリがあればこの commit で追記してもよい。)
+3. `gh pr checks <PR番号>` で 4 チェックが全 green・`mergeStateStatus` が `CLEAN` になるのを待つ。
+4. `gh pr merge <PR番号> --squash` (**`--admin` なし**、`--subject "chore(main): release X.Y.Z"` でメッセージを明示)。
+5. マージ後の後始末 (worktree/branch 撤去、primary で `git pull origin main`)。
+
+### マージ後のリリースビルド監視
+
+マージすると `Release Please` (`release.yml`, `on: push main`) が走り、`release-please` ジョブが tag `vX.Y.Z` と GitHub Release を作成し、続けて `build-mac-dmg` (署名・公証つき universal DMG) と `publish-csw` (署名・公証つき `csw` バイナリ添付) が走る。
+
+- [ ] `gh run view <id>` で全ジョブ green を確認する。
+- [ ] `gh release view vX.Y.Z` で Release が draft/prerelease でなく、`*_universal.dmg` と `csw` が添付されていることを確認する。
+- [ ] 署名・公証やアセット添付が落ちたら green になるまでデバッグする (成功を仮定しない)。
+
+技術背景 (squash とメッセージのパース注意) は個人メモリ `release-please-squash-parse-pitfall` / `autonomous-merge-after-ci` も参照。
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ cargo clippy --workspace --all-targets -- -D warnings   # lint
 cargo fmt --all                    # フォーマット
 ```
 
-GUI の実機確認は `cargo tauri dev` (要 `cargo install tauri-cli`)。デスクトップ署名/公証/DMG は GitHub Actions の `Release Please` ワークフローが担う。
+GUI の実機確認は `cargo tauri dev` (要 `cargo install tauri-cli`)。デスクトップ署名/公証/DMG は GitHub Actions の `Release Please` ワークフローが担う。リリースの実施手順 (release-please の release PR を `--admin` を使わずマージし、署名・公証つき DMG と `csw` の公開まで監視する正規手順) は [.agents/skills/core_pr_merge_checklist/SKILL.md](.agents/skills/core_pr_merge_checklist/SKILL.md) の「リリース PR (release-please) のマージ」節を参照する。ユーザーの明示指示があってから行う。
 
 LP (`website/`) のプレビューは Claude の launch 機能で `.claude/launch.json` の `lp` を起動する (preview_start で `website/` を `python3 -m http.server` 配信、EN は `/`、日本語は `/ja/`)。`website/` をルートに配信しないと相対パス (`../style.css` 等) が解決しないので、単体 HTML を file:// で開くのではなくこの設定で見る。
 


### PR DESCRIPTION
## 背景

リリースの実施手順（release-please の release PR を `--admin` を使わずマージし、署名・公証つき DMG と `csw` の公開まで監視する正規手順）が個人メモリにしか無く、リポジトリのルール/スキルに書かれていなかった。リポジトリ固有の運用はリポジトリ側を一次情報にする。

## 変更

- `core_pr_merge_checklist` スキルに「リリース PR (release-please) のマージ」節を追加。bot(GITHUB_TOKEN)製の release PR は `pull_request` 必須チェックが発火せず `BLOCKED` になるため、`--admin` を使わず release ブランチへ空コミットを push してチェックを発火 → 緑後に通常 `--squash` マージ → `Release Please` の DMG/csw 公開を監視、という手順を明記。
- `CLAUDE.md` のビルド節からこの手順へのポインタを追加。

`crates/` は不変のため `docs:`（リリース対象外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)