### PR TITLE
chore: Skill-First を強制する PreToolUse フックを追加する

### DIFF
--- a/.claude/hooks/skill-first-reminder.sh
+++ b/.claude/hooks/skill-first-reminder.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# PreToolUse (Edit|Write|MultiEdit) skill-first reminder.
+#
+# When about to edit a design / Japanese-copy / documentation surface, inject a
+# non-blocking reminder so the Skill-First Gate and cross-surface propagation are
+# consulted every time — not skipped as a "small change" and fixed only after the
+# user points it out. Fires only for the surfaces below; other edits pass silently.
+f="${CLAUDE_TOOL_INPUT_FILE_PATH:-}"
+case "$f" in
+  *website/*|*/docs/*|*README*|*/crates/desktop/ui/*|*.html|*.css|*.md) ;;
+  *) exit 0 ;;
+esac
+cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"[Skill-First ゲート] デザイン/日本語コピー/ドキュメントのサーフェスを編集しようとしています。編集前に確認すること: (1) 該当スキルを Read したか。視覚は minimalist-ui / design-taste-frontend、日本語コピー・タイポは japanese-typography-qa (§5: 用語:定義の羅列や後付けカッコ説明をしない・説明を先に述べてから用語を出す・前から読める語順・em-dash/※/絵文字禁止)、整合は docs_impl_consistency_audit。(2) この変更を全サーフェスへ伝播するか (アプリ UI・トレイ・docs ja/en・README ja/en・LP ja/en・スクショ。propagate-changes-to-all-surfaces)。(3) 完了前に旧表現を全リポ grep でゼロ確認し、UI が変わったら scripts/appshot でスクショ再生成、/audit-consistency を自分で回す。指摘される前にやる。"}}
+JSON

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,15 @@
             "command": "CMD=\"$CLAUDE_TOOL_INPUT_COMMAND\"; if echo \"$CMD\" | grep -qE '^(\\s*)git\\s+push'; then echo '[hook] git push detected. Enforcing core_ai_workflow: ensuring tests pass.' >&2 && cargo test; fi"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/skill-first-reminder.sh\""
+          }
+        ]
       }
     ]
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@
 - **「小さい/自明だから」は免除理由にならない**。フッターの寄せ・スウォッチの形・選択ハイライト・左バー——まさにこの「小さい変更」を雰囲気でやって繰り返し外している。サイズや明白さに関係なくゲートを通す。
 - **自己捕捉**: スキルを引かずに着手してしまったと気づいたら、即停止・違反を自己申告し、スキルを Read して引用したルールでやり直す。ユーザーに指摘される前に自分で直す。
 - **選び方**: 日本語の UI/LP/見出しは `japanese-typography-qa`、フロント/LP デザインは `design-taste-frontend` / `high-end-visual-design` / `minimalist-ui` 等。用途別の選び方はグローバル `~/.claude/CLAUDE.md` と各スキルの説明を参照。
+- **強制の仕組み（意志力に頼らない）**: `.claude/settings.json` の PreToolUse フック `.claude/hooks/skill-first-reminder.sh` が、`website/`・`docs/`・`README`・`crates/desktop/ui/`・`*.html/*.css/*.md` を Edit/Write する直前に、本ゲート（該当スキルを読む）と全サーフェス伝播（`propagate-changes-to-all-surfaces`）・変更後の `/audit-consistency`・スクショ再生成（`scripts/appshot`）を自動リマインドする。フックの注意が出たら従う。指摘される前に自分でゲートを通す。
 - この Gate はグローバル `~/.claude/CLAUDE.md` を一次正典とし、本ファイルで二重化する。
 
 ## プロジェクト概要


### PR DESCRIPTION
## 目的

デザイン/日本語コピー/ドキュメントを編集するたびに、指摘されてから直す後手ループに陥っていた。テキストの努力目標では守り切れないので、ハーネス側のフックで強制する。

## 変更
- `.claude/hooks/skill-first-reminder.sh`: `website/`・`docs/`・`README`・`crates/desktop/ui/`・`*.html/*.css/*.md` を Edit/Write する直前に、(1) 該当スキルを読む(視覚=minimalist-ui/design-taste-frontend、日本語コピー/タイポ=japanese-typography-qa §5、整合=docs_impl_consistency_audit)、(2) 全サーフェスへ伝播、(3) 変更後に grep 残存ゼロ・`/audit-consistency`・スクショ再生成(`scripts/appshot`)、を促すリマインダを注入。
- `.claude/settings.json`: 上記を PreToolUse(`Edit|Write|MultiEdit`)フックとして追加。既存フック(rs の clippy、git push 前 cargo test)は保全。`additionalContext` の注入のみで `permissionDecision` は出さない(権限は変えない)。
- `CLAUDE.md` §0 にこの強制の仕組みを明記。

## 検証
- `jq` で settings.json が妥当・両 PreToolUse フック登録を確認。パイプテストで一致パス→妥当 JSON(権限フィールドなし)、非一致→無出力を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)