### PR TITLE
docs(website): LP スクショ寸法を再生成後の実寸に更新

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -80,7 +80,7 @@
                             <img src="assets/logo.png" class="menu-bar-logo" alt="CSW Icon">
                         </div>
                     </div>
-                    <img src="assets/hero.png?v=0.13.1" width="1520" height="984" alt="Settings Interface" class="hero-image">
+                    <img src="assets/hero.png?v=0.14.0" width="1520" height="996" alt="Settings Interface" class="hero-image">
                 </div>
             </div>
         </section>
@@ -119,15 +119,15 @@
             </div>
             <div class="screens-bento">
                 <figure class="screen-card fade-in delay-1">
-                    <img src="assets/screen_overview.png?v=0.13.1" width="1520" height="2224" alt="CSW settings window showing an environment's paths and a per-component carry-over matrix" loading="lazy">
+                    <img src="assets/screen_overview.png?v=0.14.0" width="1520" height="2626" alt="CSW settings window showing an environment's paths and a per-component carry-over matrix" loading="lazy">
                     <figcaption>Every environment gets its own data directories. You choose per component what carries over and what stays separate; the account sign-in is always kept apart.</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
-                    <img src="assets/screen_create.png?v=0.13.1" width="1520" height="2104" alt="New-environment screen offering the three separation modes" loading="lazy">
+                    <img src="assets/screen_create.png?v=0.14.0" width="1520" height="2152" alt="New-environment screen offering the three separation modes" loading="lazy">
                     <figcaption>Create an environment in seconds. Choose how much carries over: the account only, conversations and memory too, or everything.</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
-                    <img src="assets/screen_onboarding.png?v=0.13.2" width="1520" height="1658" alt="First-run onboarding explaining that the existing setup is preserved" loading="lazy">
+                    <img src="assets/screen_onboarding.png?v=0.14.0" width="1520" height="1848" alt="First-run onboarding explaining that the existing setup is preserved" loading="lazy">
                     <figcaption>A short first-run tour shown only the first time. Your current setup is preserved as “Existing Claude” and never modified.</figcaption>
                 </figure>
             </div>

--- a/website/ja/index.html
+++ b/website/ja/index.html
@@ -80,7 +80,7 @@
                             <img src="../assets/logo.png" class="menu-bar-logo" alt="CSW Icon">
                         </div>
                     </div>
-                    <img src="../assets/ja_hero.png?v=0.13.1" width="1520" height="996" alt="Settings Interface" class="hero-image">
+                    <img src="../assets/ja_hero.png?v=0.14.0" width="1520" height="996" alt="Settings Interface" class="hero-image">
                 </div>
             </div>
         </section>
@@ -119,15 +119,15 @@
             </div>
             <div class="screens-bento">
                 <figure class="screen-card fade-in delay-1">
-                    <img src="../assets/ja_screen_overview.png?v=0.13.1" width="1520" height="2198" alt="各環境のパスと項目別の共有/分離マトリクスを表示した CSW 設定画面" loading="lazy">
+                    <img src="../assets/ja_screen_overview.png?v=0.14.0" width="1520" height="2600" alt="各環境のパスと項目別の共有/分離マトリクスを表示した CSW 設定画面" loading="lazy">
                     <figcaption>各環境は専用のデータディレクトリを持ちます。各項目を既存環境から引き継ぐか分けるかを選べ、アカウントのサインイン情報は常に分離されます。</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
-                    <img src="../assets/ja_screen_create.png?v=0.13.1" width="1520" height="1998" alt="「アカウントだけ分ける」「会話とメモリも分ける」「すべて分ける」を選べる環境作成画面" loading="lazy">
+                    <img src="../assets/ja_screen_create.png?v=0.14.0" width="1520" height="2044" alt="「アカウントだけ分ける」「会話とメモリも分ける」「すべて分ける」を選べる環境作成画面" loading="lazy">
                     <figcaption>環境は数秒で作成できます。アカウントだけ・会話とメモリも・すべて、の3つから引き継ぐ範囲を選びます。</figcaption>
                 </figure>
                 <figure class="screen-card fade-in delay-2">
-                    <img src="../assets/ja_screen_onboarding.png?v=0.13.2" width="1520" height="1622" alt="既存環境が保持されることを説明する初回オンボーディング" loading="lazy">
+                    <img src="../assets/ja_screen_onboarding.png?v=0.14.0" width="1520" height="1848" alt="既存環境が保持されることを説明する初回オンボーディング" loading="lazy">
                     <figcaption>初回だけ表示される短い案内です。現在の環境は「既存の Claude」として保持され、変更されることはありません。</figcaption>
                 </figure>
             </div>


### PR DESCRIPTION
## 概要
#128 で日英8枚のアプリスクショを再生成したが、LP の `<img>` の `width`/`height` 属性が旧寸法のまま、`?v=` キャッシュバスターも据え置きだった。属性寸法が実画像とずれると CLS の予約枠が狂い、画像の歪み・レイアウトのジャンプを起こす（メモリ `flaky-anchor-landing-is-cls-reserve-image-dims`）。

## 変更
- `website/index.html`・`website/ja/index.html` のスクショ/ヒーロー計8枚の `width`/`height` を再生成後の実寸（`sips` 実測）に更新。
- キャッシュバスターを `?v=0.14.0` に統一（同名ファイルの更新をブラウザに確実に取り直させる）。

## 検証
CDP 実寸で日英両ページの全8枚について、属性比==画像の自然比（ratioDelta 0.0000＝歪み・CLS ゼロ）・横スクロールなし・JS 例外なしを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)