### PR TITLE
fix(desktop): DMG 案内バナーが常時表示になる問題を修正する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ LP (`website/`) のプレビューは Claude の launch 機能で `.claude/launc
    - 公開 Web アセット (LP) と内部ドキュメント・エージェントファイルを決して混同しない。
 3. **Asset Generation**: アプリのスクリーンショットは上記の通り実アプリから各ロケールで撮影する（本項の対象外）。OG 画像等、スクリーンショット以外の画像内テキストを翻訳するときは生成 AI を使わず、元の視覚デザインを変えてしまうことを禁止する。ピクセル等価の翻訳が要るときは正確なプログラム処理 (例: Python + Pillow) を使う。
 4. **CI/CD Feedback Loops**: commit 後は必ず GitHub Actions を監視する。ワークフローが落ちたら緑になるまでデバッグして push する。成功を仮定しない。
+5. **hidden 属性は author CSS の display に負ける**: `display: flex` 等を指定した要素を `hidden` 属性で表示制御するときは、必ず `.クラス[hidden] { display: none; }` を併記して再表明する（`.view[hidden]` パターン）。UA スタイルの `[hidden]` は author の display 指定より弱く、属性だけでは隠れない。あわせて表示制御の検証は `hidden` プロパティの値でなく computed display と実寸（getBoundingClientRect）で行い、**「何も操作しない素の既定状態」を必ず実描画で 1 枚確認**する（v0.16.0 で DMG 案内バナーが常時表示のまま出荷された再発防止。発見経路はスクショ再生成への写り込みだった。派生物の再生成は既定状態の検証機会でもある）。
 
 ## 5. フィードバックの教訓化 (Feedback Memory Protocol / Self-Correction Mandate)
 

--- a/crates/desktop/ui/style.css
+++ b/crates/desktop/ui/style.css
@@ -354,6 +354,9 @@ code, .code-line { font-family: var(--font-mono); }
 
 /* Leftover installer disk image prompt: flat card in the note-card idiom, with
    the primary action on the right (macOS button order). */
+/* display:flex would defeat the hidden attribute (author styles beat the UA's
+   [hidden]{display:none}), so re-assert it like .view[hidden] does. */
+.dmg-banner[hidden] { display: none; }
 .dmg-banner {
   display: flex;
   /* At the real window minimum (600px) the actions wrap below the text and


### PR DESCRIPTION
## 概要

v0.16.0 の DMG 取り出し案内バナーが、ディスクイメージのマウント状態に関係なく常時表示になる問題の修正です。スクリーンショット再生成時に既定状態のバナーが写り込んだことで発見しました。

## 原因

`.dmg-banner { display: flex }` (author スタイル) が UA スタイルの `[hidden] { display: none }` より優先されるため、`hidden` 属性を立てても視覚的に隠れていませんでした。「あとで」「取り出す」も属性は更新するものの見た目は消えません。実装時の検証が `hidden` プロパティの値と手動で表示させた状態の確認に留まり、「何も操作しない素の既定状態」の実描画確認が抜けていました。

## 修正

- 既存の `.view[hidden]` パターンに合わせて `.dmg-banner[hidden] { display: none; }` を再表明
- CLAUDE.md のコーディング規約に、hidden 属性の再表明義務と「素の既定状態を実描画で確認する」検証原則を追記

## 検証

- RED: 修正前、素の状態で computed display が flex・実寸あり (可視) を headless で実測
- GREEN: 修正後、既定状態の非表示 / dmgMounts 設定時の表示 / 「あとで」後の非表示 / 「取り出す」後の非表示、の 4 状態を computed display と getBoundingClientRect の実測で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)